### PR TITLE
Fix curator subagent writing to auto-memory instead of rememora DB

### DIFF
--- a/src/curator.rs
+++ b/src/curator.rs
@@ -77,9 +77,22 @@ pub fn curate(transcript: &str, project: &str, dry_run: bool) -> Result<Curation
 }
 
 /// Call a Claude Code subagent via `claude -p` with a specific model.
+///
+/// Uses `--tools Bash` to restrict the subagent to only the Bash tool
+/// (prevents file writes to auto-memory). Grants scoped bash access via
+/// `--allowedTools` so it can run `rememora` CLI commands without prompting.
 pub fn call_subagent(prompt: &str, model: &str) -> Result<String> {
     let output = Command::new("claude")
-        .args(["-p", prompt, "--model", model])
+        .args([
+            "-p",
+            prompt,
+            "--model",
+            model,
+            "--tools",
+            "Bash",
+            "--allowedTools",
+            "Bash(rememora:*)",
+        ])
         .output()
         .context("Failed to run 'claude' CLI. Is Claude Code installed?")?;
 


### PR DESCRIPTION
## Summary

- The curator's `call_subagent()` invoked `claude -p` without restricting available tools, so the Sonnet subagent fell back to Claude Code's file-based auto-memory instead of running `rememora save` via bash
- Added `--tools Bash` (restricts to Bash only — no Write/Edit) and `--allowedTools "Bash(rememora:*)"` (auto-approves rememora commands) to `call_subagent()`
- Part of #45 (Autonomous memory curator)

## Test plan

- [x] Live curation: 7 memories saved to rememora SQLite DB
- [x] Dedup verification: re-curating same session produces 0 adds
- [x] No file-based memory pollution (no `.md` files written to auto-memory dir)
- [x] All existing tests pass (`cargo test`)