### PR TITLE
Fix plugin marketplace discovery: move marketplace.json to repo root

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "rememora",
-      "source": "./",
+      "source": "./plugin",
       "description": "Persistent cross-agent memory for Claude Code. Auto-saves decisions, bug fixes, and patterns. Searches memory before implementations.",
       "version": "1.0.0",
       "author": {

--- a/src/commands/tui.rs
+++ b/src/commands/tui.rs
@@ -294,12 +294,10 @@ fn handle_key(app: &mut App, code: KeyCode, conn: &Connection) -> Result<()> {
                     app.detail_scroll = 0;
                 }
             }
-            KeyCode::Enter => {
+            KeyCode::Enter if !app.search_results.is_empty() => {
                 // Keep search results visible, exit input mode
-                if !app.search_results.is_empty() {
-                    app.search_active = false;
-                    app.focus = Panel::Detail;
-                }
+                app.search_active = false;
+                app.focus = Panel::Detail;
             }
             _ => {}
         }
@@ -327,12 +325,10 @@ fn handle_key(app: &mut App, code: KeyCode, conn: &Connection) -> Result<()> {
         KeyCode::Char('l') => {
             app.focus = app.focus.next();
         }
-        KeyCode::Esc => {
+        KeyCode::Esc if !app.search_results.is_empty() => {
             // Clear search results if any
-            if !app.search_results.is_empty() {
-                app.search_results.clear();
-                app.search_state.select(None);
-            }
+            app.search_results.clear();
+            app.search_state.select(None);
         }
         KeyCode::Char('j') | KeyCode::Down => match app.focus {
             Panel::Projects => {


### PR DESCRIPTION
## Summary
- `claude plugin marketplace add Rememora/rememora` fails with `Marketplace file not found at .../.claude-plugin/marketplace.json` because the file lives at `plugin/.claude-plugin/marketplace.json` — Claude Code looks at the repo root, not nested under `plugin/`.
- Moves the marketplace manifest to `.claude-plugin/marketplace.json` at repo root, with `source: "./plugin"` pointing at the plugin directory. `plugin.json` stays inside `plugin/`.

## Test plan
- [ ] After merge, run `claude plugin marketplace add Rememora/rememora` and confirm it succeeds
- [ ] Verify `.claude-plugin/marketplace.json` present on `main` via GitHub UI
- [ ] Verify plugin installs and loads