### PR TITLE
fix(plugin): debounce Stop-hook curate to prevent stampede

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,10 @@ This gives you hooks + skills that work automatically — no manual commands nee
 
 After installing, restart Claude Code. The plugin auto-detects your project from the working directory.
 
+**Configuration:**
+
+- `REMEMORA_CURATE_COOLDOWN_SECS` (default: `300`) — minimum seconds between automatic curation runs from the Claude Code `Stop` hook, per session. The Stop hook fires after every agent turn, so without a cooldown, long sessions stampede `rememora curate` processes. Set to `0` to disable throttling. A final curation pass always runs at `SessionEnd` regardless of cooldown, so the tail of the session is never lost.
+
 ### Claude Code (Alternative: CLAUDE.md)
 
 If you prefer manual control, add to `~/.claude/CLAUDE.md`:

--- a/plugin/scripts/session-end.sh
+++ b/plugin/scripts/session-end.sh
@@ -1,11 +1,31 @@
 #!/usr/bin/env bash
-# Rememora SessionEnd hook — closes the active session.
-# Runs automatically when the Claude Code session ends.
-
+# Rememora SessionEnd hook — closes the active session and runs a final curation pass.
+# Runs once per Claude Code session end; pairs with stop-curate.sh's per-turn cooldown
+# by guaranteeing the tail of the session is captured even if the last Stop hook was
+# inside the cooldown window.
 set -euo pipefail
 
 if ! command -v rememora &>/dev/null; then
   exit 0
 fi
 
+INPUT=$(cat)
+CWD=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('cwd',''))" 2>/dev/null || echo "")
+SESSION_ID=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('session_id',''))" 2>/dev/null || echo "")
+
 rememora session end-active --auto-summary 2>/dev/null || true
+
+if [ -n "$CWD" ] && [ -n "$SESSION_ID" ]; then
+  ENCODED_CWD=$(echo "$CWD" | sed 's|/|-|g')
+  JSONL_PATH="$HOME/.claude/projects/${ENCODED_CWD}/${SESSION_ID}.jsonl"
+  PROJECT=$(basename "$CWD")
+
+  if [ -f "$JSONL_PATH" ]; then
+    (
+      rememora curate --file "$JSONL_PATH" --project "$PROJECT" 2>/dev/null || true
+    ) &
+  fi
+
+  LOCK_DIR="${TMPDIR:-/tmp}"
+  rm -f "${LOCK_DIR%/}/rememora-curate-${SESSION_ID}.last" 2>/dev/null || true
+fi

--- a/plugin/scripts/stop-curate.sh
+++ b/plugin/scripts/stop-curate.sh
@@ -33,6 +33,25 @@ fi
 # Detect project name from CWD
 PROJECT=$(basename "$CWD")
 
+# Debounce: skip if this session curated within the cooldown window.
+# Claude Code's Stop hook fires per agent turn, not per session — without this gate,
+# long sessions stampede `rememora curate` (and its `claude -p` signal-detector child)
+# dozens of times concurrently. Per-session lockfile = fresh bucket each new session,
+# auto-cleaned from /tmp on reboot. Set REMEMORA_CURATE_COOLDOWN_SECS=0 to disable.
+COOLDOWN="${REMEMORA_CURATE_COOLDOWN_SECS:-300}"
+LOCK_DIR="${TMPDIR:-/tmp}"
+LOCK="${LOCK_DIR%/}/rememora-curate-${SESSION_ID}.last"
+
+if [ -f "$LOCK" ]; then
+  # Portable mtime: BSD stat (macOS) first, GNU stat (Linux) fallback.
+  LAST=$(stat -f %m "$LOCK" 2>/dev/null || stat -c %Y "$LOCK" 2>/dev/null || echo 0)
+  NOW=$(date +%s)
+  if [ $((NOW - LAST)) -lt "$COOLDOWN" ]; then
+    exit 0
+  fi
+fi
+touch "$LOCK"
+
 # Fork curation to background — must not block the agent
 (
   rememora curate --file "$JSONL_PATH" --project "$PROJECT" 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Add per-session cooldown gate in `plugin/scripts/stop-curate.sh` — Claude Code's `Stop` hook fires per agent turn, not per session, so long sessions stampeded `rememora curate` + its two `claude -p` children. Tunable via `REMEMORA_CURATE_COOLDOWN_SECS` (default 300s, set to `0` to disable).
- Rewrite `plugin/scripts/session-end.sh` to run a final catch-up curate and clean the session's lockfile, guaranteeing the tail of a session is captured even if the last `Stop` fire was inside the cooldown window.
- Document the env var in `README.md`.

## Why

Observed in a real session before the fix: **37 concurrent `claude -p` processes** and **~105 total rememora-related processes** piled up from a single multi-hour Claude Code session. Each Stop hook fork stays alive for the duration of a `curate` call (Haiku signal gate + optionally Sonnet AUDN curator), which can be minutes — new fires stack on top before earlier ones finish. Result: CPU burn, API token burn, and a voice-notification hook chain firing in lockstep.

## Design notes

- **Lockfile at `${TMPDIR:-/tmp}/rememora-curate-${SESSION_ID}.last`** — per-session means each fresh Claude Code session starts with an empty bucket (no cross-session surprises); `/tmp` auto-cleans on reboot so no long-lived state accumulates.
- **`touch` before the fork** — rapid-fire second fires see the fresh mtime and exit before spawning anything.
- **Portable `stat`** — `stat -f %m` (BSD/macOS) with a `stat -c %Y` (GNU/Linux) fallback, since rememora targets both.
- **SessionEnd as safety net** — if the session ends inside the cooldown window, the tail would otherwise be missed; SessionEnd now runs a final curate pass (once, no cooldown needed) and unlinks the lockfile.
- **Not changing `curate`'s CLI** — a `--cooldown-secs` flag on the Rust side would be dead weight; the shell gate already prevents the process from spawning when throttled.

## Test plan

- [x] `bash -n plugin/scripts/{stop-curate,session-end}.sh` — syntax clean
- [x] Cold run → lockfile created, curate runs
- [x] Second run within cooldown → mtime unchanged, curate NOT invoked
- [x] `REMEMORA_CURATE_COOLDOWN_SECS=0` → gate bypassed, curate runs again
- [x] SessionEnd hook → curate runs + lockfile removed
- [x] No straggler processes after test harness completes
- [ ] Install patched plugin + run a 10+ turn real session → `pgrep -f "claude -p" | wc -l` stays ≤2 (to be verified after merge & plugin update)
- [ ] Linux syntax sanity check (BSD vs GNU stat) — fallback path untested on CI

## Closes

Fixes a latent issue reported today — no existing issue, but I can file one if desired.