### PR TITLE
fix(plugin): enforce curate concurrency with pgrep gate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "rememora",
       "source": "./plugin",
       "description": "Persistent cross-agent memory for Claude Code. Auto-saves decisions, bug fixes, and patterns. Searches memory before implementations.",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "author": {
         "name": "Rememora"
       },

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rememora",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Persistent cross-agent memory. Automatically saves decisions, bug fixes, and patterns across sessions. Semantically retrieves context when you need it.",
   "author": {
     "name": "Rememora"

--- a/plugin/scripts/stop-curate.sh
+++ b/plugin/scripts/stop-curate.sh
@@ -33,28 +33,40 @@ fi
 # Detect project name from CWD
 PROJECT=$(basename "$CWD")
 
-# Debounce: skip if this session curated within the cooldown window.
-# Claude Code's Stop hook fires per agent turn, not per session — without this gate,
-# long sessions stampede `rememora curate` (and its `claude -p` signal-detector child)
-# dozens of times concurrently. Per-session lockfile = fresh bucket each new session,
-# auto-cleaned from /tmp on reboot. Set REMEMORA_CURATE_COOLDOWN_SECS=0 to disable.
+# Two gates guard the per-turn Stop-hook stampede of `rememora curate` (and its
+# `claude -p` signal-detector child).
+#
+# 1) Concurrency: at most one curate in-flight per session. Checked against the
+#    kernel via pgrep — the jsonl path carries SESSION_ID, so the match is
+#    unambiguous. This is the primary gate: it stays correct even when curate
+#    runtime exceeds the frequency cooldown.
+# 2) Frequency: at least COOLDOWN seconds between consecutive *finishes*. The
+#    stamp is touched after curate returns, so the window means what its name
+#    says (not start-to-start).
+#
+# Set REMEMORA_CURATE_COOLDOWN_SECS=0 to disable the frequency gate.
+if pgrep -f "rememora curate --file .*${SESSION_ID}" >/dev/null 2>&1; then
+  exit 0
+fi
+
 COOLDOWN="${REMEMORA_CURATE_COOLDOWN_SECS:-300}"
 LOCK_DIR="${TMPDIR:-/tmp}"
-LOCK="${LOCK_DIR%/}/rememora-curate-${SESSION_ID}.last"
+STAMP="${LOCK_DIR%/}/rememora-curate-${SESSION_ID}.last"
 
-if [ -f "$LOCK" ]; then
+if [ -f "$STAMP" ]; then
   # Portable mtime: BSD stat (macOS) first, GNU stat (Linux) fallback.
-  LAST=$(stat -f %m "$LOCK" 2>/dev/null || stat -c %Y "$LOCK" 2>/dev/null || echo 0)
+  LAST=$(stat -f %m "$STAMP" 2>/dev/null || stat -c %Y "$STAMP" 2>/dev/null || echo 0)
   NOW=$(date +%s)
   if [ $((NOW - LAST)) -lt "$COOLDOWN" ]; then
     exit 0
   fi
 fi
-touch "$LOCK"
 
-# Fork curation to background — must not block the agent
+# Fork curation to background — must not block the agent. Stamp updates on
+# completion so the cooldown gate measures idle time, not launch cadence.
 (
   rememora curate --file "$JSONL_PATH" --project "$PROJECT" 2>/dev/null || true
+  touch "$STAMP"
 ) &
 
 exit 0


### PR DESCRIPTION
## Summary

Stop-hook curate stampede — structural fix, finishing the job started in #62.

#62 shipped a 300s per-session lockfile debounce, but that only bounded *frequency between starts*, not *concurrency between starts and finishes*. Real `rememora curate` runtime (dominated by the `claude -p` signal-detector child) regularly exceeds 5 minutes. When `curate_runtime > cooldown`, every Stop hook that fires in the overlap window spawns a second curate while the first is still running.

**Observed today before this fix: 110 concurrent `rememora curate` procs + 55 `claude -p` children across 29 live sessions** (≈2.1 in-flight per session, not the bounded 1).

## Root cause

`plugin/scripts/stop-curate.sh` used file mtime as the primary gate:
1. If `LOCK` exists and `now - mtime(LOCK) < cooldown` → skip.
2. Else `touch LOCK` (at **start**) and fork curate.

Two structural flaws:

- mtime answers *"when did we last start?"*, not *"is one already running?"* — you cannot gate concurrency with a timestamp.
- `touch` at start means the cooldown window is start-to-start. A 6-minute curate with a 5-minute cooldown lets a second curate fire 1 minute before the current one finishes, even in a single session.

## Fix

Two independent gates in `plugin/scripts/stop-curate.sh`:

1. **Concurrency (new, primary)** — `pgrep -f "rememora curate --file .*\${SESSION_ID}"`. The jsonl path carries the session UUID so the match is unambiguous. Kernel truth, always correct, even when curate runtime exceeds the cooldown.
2. **Frequency (kept, secondary)** — existing 300s lockfile gate, but the stamp now updates *post-run* (`touch "\$STAMP"` at the tail of the curate subshell). The window now measures *idle since last finish*, which is what its name always implied.

\`REMEMORA_CURATE_COOLDOWN_SECS=0\` still disables the frequency gate. Concurrency gate is always on.

## Verification

End-to-end test with a mocked slow \`rememora\` on \`PATH\`:

- 5 rapid Stop-hook fires for the same session → **1 in-flight curate** (before this fix: up to 5, in practice 2–4 due to process startup time).
- \`bash -n\` clean.

## Version

Plugin \`1.0.1 → 1.0.2\` (patch — behavior-preserving bug fix; users finally get the contract the debounce always implied).

## Follow-up

The Claude Code \`monitors\` manifest key (v2.1.105) replaces the whole dual-gate architecture with a single long-lived tailing process per session — structurally serialized, no lockfiles. Worth a dedicated issue; not in scope here.