### PR TITLE
docs: document Stop-hook curator + clarify cooldown semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ After installing, restart Claude Code. The plugin auto-detects your project from
 
 **Configuration:**
 
-- `REMEMORA_CURATE_COOLDOWN_SECS` (default: `300`) — minimum seconds between automatic curation runs from the Claude Code `Stop` hook, per session. The Stop hook fires after every agent turn, so without a cooldown, long sessions stampede `rememora curate` processes. Set to `0` to disable throttling. A final curation pass always runs at `SessionEnd` regardless of cooldown, so the tail of the session is never lost.
+- `REMEMORA_CURATE_COOLDOWN_SECS` (default: `300`) — minimum idle seconds between automatic curation runs from the Claude Code `Stop` hook, per session. The Stop hook fires after every agent turn. The plugin enforces **at most one in-flight `rememora curate` per session** via a kernel-level concurrency gate (`pgrep` on the session ID); this setting layers on top as a secondary frequency gate, bounding how long to wait after a curate *finishes* before another is allowed. Set to `0` to disable the cooldown — the concurrency gate still applies. A final curation pass always runs at `SessionEnd` regardless of cooldown, so the tail of the session is never lost.
 
 ### Claude Code (Alternative: CLAUDE.md)
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -5,6 +5,8 @@ Persistent cross-agent memory for Claude Code. Automatically saves decisions, bu
 ## What it does
 
 - **SessionStart hook**: Loads project context from rememora automatically
+- **Stop hook**: Curates memories from the transcript after each agent turn (one in-flight curate per session, via a kernel-level concurrency gate)
+- **SessionEnd hook**: Closes the active rememora session and runs a final curation pass
 - **Model-invoked save skill**: Claude autonomously saves knowledge when it makes decisions, fixes bugs, or discovers patterns
 - **Model-invoked search skill**: Claude autonomously searches memory before implementing or when encountering unfamiliar code
 - **`/rememora` command**: Manually trigger memory save or search
@@ -36,17 +38,19 @@ claude plugin install rememora@rememora --scope project
    - Codebase patterns or conventions
    - Important entities (services, APIs, configs)
 3. Before implementation, Claude **autonomously searches** for relevant prior knowledge
-4. On **session end**, the hook closes the active rememora session
+4. After each agent turn, the **Stop hook** forks `rememora curate` against the session transcript to extract anything Claude missed. At most one curate runs in-flight per session (enforced by a `pgrep`-based concurrency gate); a secondary `REMEMORA_CURATE_COOLDOWN_SECS` (default `300`) frequency gate rate-limits consecutive runs
+5. On **session end**, the hook closes the active rememora session and runs a final curation pass so the tail of the session is never lost
 
 ## Plugin structure
 
 ```
 plugin/
 ├── hooks/
-│   └── hooks.json              # SessionStart + SessionEnd hooks
+│   └── hooks.json              # SessionStart + Stop + SessionEnd hooks
 ├── scripts/
 │   ├── session-start.sh        # Load context + start session
-│   └── session-end.sh          # End active session
+│   ├── stop-curate.sh          # Fork `rememora curate` per agent turn
+│   └── session-end.sh          # End active session + final curation pass
 ├── skills/
 │   ├── rememora-save/
 │   │   └── SKILL.md            # Model-invoked: autonomous save


### PR DESCRIPTION
Follow-up doc pass after #63 / plugin v1.0.2.

## What changed

- **\`plugin/README.md\`**: added the Stop hook (and \`scripts/stop-curate.sh\`) to the feature list, \"How it works\" walkthrough, and plugin structure tree. The hook has been shipping since #62 but the plugin README still advertised a SessionStart + SessionEnd plugin.
- **Top-level \`README.md\`**: rewrote the \`REMEMORA_CURATE_COOLDOWN_SECS\` paragraph. It previously described the cooldown as *the* anti-stampede mechanism, which was true under v1.0.1's single-gate design but is no longer accurate after v1.0.2. The concurrency gate (kernel-level \`pgrep\`) is now the guarantee; the cooldown is a secondary frequency limiter that measures idle-since-finished. Setting \`=0\` disables the cooldown but keeps the concurrency gate active.

## Scope

Docs only. No code change, no version bump, no release.