### PR TITLE
fix(curate): stop recursive child session curation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "rememora",
       "source": "./plugin",
       "description": "Persistent cross-agent memory for Claude Code. Auto-saves decisions, bug fixes, and patterns. Searches memory before implementations.",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "author": {
         "name": "Rememora"
       },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2582,7 +2582,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rememora"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rememora"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 description = "Cross-agent memory system for AI coding assistants"
 license = "MIT"

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rememora",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Persistent cross-agent memory. Automatically saves decisions, bug fixes, and patterns across sessions. Semantically retrieves context when you need it.",
   "author": {
     "name": "Rememora"

--- a/plugin/scripts/stop-curate.sh
+++ b/plugin/scripts/stop-curate.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+# Do not curate our own children. `rememora curate` spawns `claude -p`
+# subprocesses for signal detection / AUDN curation; each child gets its own
+# session_id and fires its own Stop hook. Without this gate, curate recursively
+# curates itself.
+[ -n "${REMEMORA_CURATE_CHILD:-}" ] && exit 0
+
 # Rememora Stop hook — curates memories from the current session transcript.
 # Runs in the background after each Claude Code agent turn completes.
 # Must never block the agent — all work is forked to a subshell.

--- a/src/curator.rs
+++ b/src/curator.rs
@@ -82,17 +82,7 @@ pub fn curate(transcript: &str, project: &str, dry_run: bool) -> Result<Curation
 /// (prevents file writes to auto-memory). Grants scoped bash access via
 /// `--allowedTools` so it can run `rememora` CLI commands without prompting.
 pub fn call_subagent(prompt: &str, model: &str) -> Result<String> {
-    let output = Command::new("claude")
-        .args([
-            "-p",
-            prompt,
-            "--model",
-            model,
-            "--tools",
-            "Bash",
-            "--allowedTools",
-            "Bash(rememora:*)",
-        ])
+    let output = build_subagent_command(prompt, model)
         .output()
         .context("Failed to run 'claude' CLI. Is Claude Code installed?")?;
 
@@ -102,6 +92,24 @@ pub fn call_subagent(prompt: &str, model: &str) -> Result<String> {
     }
 
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+fn build_subagent_command(prompt: &str, model: &str) -> Command {
+    let mut cmd = Command::new("claude");
+    cmd.args([
+        "-p",
+        prompt,
+        "--model",
+        model,
+        "--tools",
+        "Bash",
+        "--allowedTools",
+        "Bash(rememora:*)",
+    ])
+    // Mark curate-spawned Claude Code children so their Stop hooks do not
+    // recursively curate the child session JSONL.
+    .env("REMEMORA_CURATE_CHILD", "1");
+    cmd
 }
 
 #[cfg(test)]
@@ -137,5 +145,15 @@ mod tests {
         let prompt = SIGNAL_GATE_PROMPT.replace("{transcript}", transcript);
         assert!(prompt.contains("some transcript"));
         assert!(!prompt.contains("{transcript}"));
+    }
+
+    #[test]
+    fn test_subagent_command_marks_curate_child() {
+        let cmd = build_subagent_command("test prompt", "haiku");
+        let env_value = cmd
+            .get_envs()
+            .find_map(|(key, value)| (key == "REMEMORA_CURATE_CHILD").then_some(value));
+
+        assert_eq!(env_value.flatten(), Some(std::ffi::OsStr::new("1")));
     }
 }


### PR DESCRIPTION
## Summary
- mark `rememora curate` Claude Code subagents with `REMEMORA_CURATE_CHILD=1`
- make the plugin Stop hook exit immediately for curate-spawned child sessions
- bump CLI to 0.3.3 and plugin manifest/marketplace versions to 1.1.0

Refs #65.

## Validation
- `git diff --check`
- `cargo test`
- `cargo clippy`
- `REMEMORA_CURATE_CHILD=1 plugin/scripts/stop-curate.sh; echo exit:$?` -> `exit:0`

## Notes
This prevents the recursion where curate-spawned `claude -p` children get their own session IDs, fire Stop hooks, and recursively curate their own child JSONLs.