### PR TITLE
fix(plugin): fully detach curate subprocess to stop blocking main thread

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rememora",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Persistent cross-agent memory. Automatically saves decisions, bug fixes, and patterns across sessions. Semantically retrieves context when you need it.",
   "author": {
     "name": "Rememora"

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -38,7 +38,7 @@ claude plugin install rememora@rememora --scope project
    - Codebase patterns or conventions
    - Important entities (services, APIs, configs)
 3. Before implementation, Claude **autonomously searches** for relevant prior knowledge
-4. After each agent turn, the **Stop hook** forks `rememora curate` against the session transcript to extract anything Claude missed. At most one curate runs in-flight per session (enforced by a `pgrep`-based concurrency gate); a secondary `REMEMORA_CURATE_COOLDOWN_SECS` (default `300`) frequency gate rate-limits consecutive runs
+4. After each agent turn, the **Stop hook** forks `rememora curate` against the session transcript to extract anything Claude missed. The curate process is fully detached — launched in its own session via `setsid` (or `nohup` + `disown` on stock macOS) with stdin/stdout/stderr redirected to `/dev/null`, so it cannot hold the hook's pipe and block Claude Code waiting for EOF. At most one curate runs in-flight per session (enforced by a `pgrep`-based concurrency gate); a secondary `REMEMORA_CURATE_COOLDOWN_SECS` (default `300`) frequency gate rate-limits consecutive runs
 5. On **session end**, the hook closes the active rememora session and runs a final curation pass so the tail of the session is never lost
 
 ## Plugin structure

--- a/plugin/scripts/stop-curate.sh
+++ b/plugin/scripts/stop-curate.sh
@@ -68,11 +68,28 @@ if [ -f "$STAMP" ]; then
   fi
 fi
 
-# Fork curation to background — must not block the agent. Stamp updates on
-# completion so the cooldown gate measures idle time, not launch cadence.
-(
-  rememora curate --file "$JSONL_PATH" --project "$PROJECT" 2>/dev/null || true
-  touch "$STAMP"
-) &
+# Fork curation to a fully detached background process.
+#
+# The Stop hook's stdout is a pipe Claude Code reads until EOF. Plain `&`
+# backgrounds scheduling but does NOT close inherited file descriptors — the
+# curate subprocess keeps the pipe's write-end open, so Claude Code waits for
+# curate (and its `claude -p` children) to exit, blocking the next user turn
+# for as long as curation runs. Observed: 10–97 min hangs in live sessions.
+#
+# Fix: redirect all three std streams on the outer launch AND place curate in
+# its own session via setsid/nohup so no descendant holds the hook's pipe.
+if command -v setsid >/dev/null 2>&1; then
+  setsid bash -c '
+    rememora curate --file "$1" --project "$2" >/dev/null 2>&1 || true
+    touch "$3"
+  ' _ "$JSONL_PATH" "$PROJECT" "$STAMP" </dev/null >/dev/null 2>&1 &
+else
+  # Stock macOS has no setsid; nohup + disown achieves equivalent detachment.
+  nohup bash -c '
+    rememora curate --file "$1" --project "$2" >/dev/null 2>&1 || true
+    touch "$3"
+  ' _ "$JSONL_PATH" "$PROJECT" "$STAMP" </dev/null >/dev/null 2>&1 &
+  disown
+fi
 
 exit 0


### PR DESCRIPTION
## Summary
- Stop hook backgrounded `rememora curate` with `&` but only redirected stderr, so the curate child inherited the hook's stdout pipe. Claude Code waits for pipe EOF, not for the hook's PID — curate keeping stdout open meant the next user prompt was blocked for as long as curate ran (observed 10–97 min hangs in live ana sessions).
- Relaunch the curate subshell via `setsid` (or `nohup` + `disown` on stock macOS) with `</dev/null >/dev/null 2>&1` on the outer launch so the child cannot hold the hook's pipe.
- Bump plugin to **v1.1.1** and document the detachment invariant in `plugin/README.md` so it doesn't regress.

## Root cause
`&` backgrounds scheduling — it does not close inherited file descriptors. `2>/dev/null` only closed stderr. Classic Unix "how to actually detach" trap: stdout lived on in the backgrounded subshell and Claude Code blocked waiting for pipe EOF.

## Test plan
- [x] Ran the patched hook with a stub that `sleep 30`s. Hook returned in **565 ms** (before: would block ~30 s).
- [x] Fired the hook twice in quick succession — second returned in **484 ms** via the existing `pgrep` gate; only one curate spawned.
- [x] Verified `ps -o pgid=` shows the curate process in its own process group, distinct from the invoking shell.
- [ ] After merge, monitor ana sessions for `hook_cancelled` events with command `stop-curate.sh` (expected: zero).

## Notes
- The `pgrep` concurrency gate and 300s cooldown from v1.0.2 are untouched.
- No changes to SessionStart or SessionEnd — those are synchronous by design.
- Follow-up (separate): investigate *why* `rememora curate` itself can take 46+ min on some sessions — the detachment fix only stops curate from blocking the main loop.