### PR TITLE
feat(analytics): agent invocation telemetry per LLM call

### DIFF
--- a/src/commands/consolidate.rs
+++ b/src/commands/consolidate.rs
@@ -104,7 +104,19 @@ pub fn run(conn: &Connection, args: &ConsolidateArgs, json_output: bool) -> Resu
         prompt
     };
 
-    let output = curator::call_subagent(&full_prompt, "sonnet")?;
+    let subagent_output = curator::call_subagent(&full_prompt, "sonnet")?;
+    let output = subagent_output.text;
+
+    // Record the consolidate subagent call so it appears in `rememora usage`.
+    rememora::models::agent_invocation::try_insert(
+        conn,
+        &rememora::models::agent_invocation::record_from_subagent(
+            rememora::models::agent_invocation::Caller::Consolidate,
+            project.map(str::to_string),
+            None,
+            &subagent_output.telemetry,
+        ),
+    );
 
     // Complete the consolidation run
     let actions_json = serde_json::json!({"output": &output[..output.len().min(1000)]}).to_string();

--- a/src/commands/curate.rs
+++ b/src/commands/curate.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 
 use rememora::curator::{self, Signal};
 use rememora::jsonl;
+use rememora::models::agent_invocation::{self, Caller};
 use rememora::models::watermark;
 
 pub struct CurateArgs {
@@ -105,9 +106,27 @@ fn curate_file(
     }
 
     // Signal gate
-    let signal = curator::signal_gate(&transcript)?;
+    let gate = curator::signal_gate(&transcript)?;
 
-    if signal == Signal::No {
+    // Record the signal-gate call if the subagent actually ran (it short-
+    // circuits for transcripts shorter than MIN_TRANSCRIPT_CHARS).
+    let project_for_telemetry = args
+        .project
+        .clone()
+        .or_else(|| detect_project_from_path(path).map(str::to_string));
+    if let Some(t) = &gate.telemetry {
+        agent_invocation::try_insert(
+            conn,
+            &agent_invocation::record_from_subagent(
+                Caller::SignalGate,
+                project_for_telemetry.clone(),
+                None,
+                t,
+            ),
+        );
+    }
+
+    if gate.signal == Signal::No {
         // Update watermark even if no signal — don't re-process
         watermark::set(conn, &path_str, parse_result.new_offset, parse_result.lines_processed as u64)?;
         watermark::log_action(conn, &path_str, "noop", None, "No signal detected", "")?;
@@ -131,6 +150,19 @@ fn curate_file(
 
     // Run curator
     let result = curator::curate(&transcript, project, args.dry_run)?;
+
+    // Record the curator call.
+    if let Some(t) = &result.telemetry {
+        agent_invocation::try_insert(
+            conn,
+            &agent_invocation::record_from_subagent(
+                Caller::Curator,
+                Some(project.to_string()),
+                None,
+                t,
+            ),
+        );
+    }
 
     // Update watermark
     watermark::set(conn, &path_str, parse_result.new_offset, parse_result.lines_processed as u64)?;
@@ -162,7 +194,7 @@ fn curate_file(
     Ok(FileResult::Curated)
 }
 
-fn curate_stdin(_conn: &Connection, args: &CurateArgs, json_output: bool) -> Result<()> {
+fn curate_stdin(conn: &Connection, args: &CurateArgs, json_output: bool) -> Result<()> {
     let mut input = String::new();
     std::io::stdin()
         .read_to_string(&mut input)
@@ -187,8 +219,20 @@ fn curate_stdin(_conn: &Connection, args: &CurateArgs, json_output: bool) -> Res
 
     let transcript = jsonl::render_transcript(&parse_result.entries);
 
-    let signal = curator::signal_gate(&transcript)?;
-    if signal == Signal::No {
+    let gate = curator::signal_gate(&transcript)?;
+    let stdin_project = args.project.clone();
+    if let Some(t) = &gate.telemetry {
+        agent_invocation::try_insert(
+            conn,
+            &agent_invocation::record_from_subagent(
+                Caller::SignalGate,
+                stdin_project.clone(),
+                None,
+                t,
+            ),
+        );
+    }
+    if gate.signal == Signal::No {
         if json_output {
             println!("{{\"status\":\"no_signal\",\"message\":\"No signal detected\"}}");
         } else {
@@ -199,6 +243,18 @@ fn curate_stdin(_conn: &Connection, args: &CurateArgs, json_output: bool) -> Res
 
     let project = args.project.as_deref().unwrap_or("unknown");
     let result = curator::curate(&transcript, project, args.dry_run)?;
+
+    if let Some(t) = &result.telemetry {
+        agent_invocation::try_insert(
+            conn,
+            &agent_invocation::record_from_subagent(
+                Caller::Curator,
+                Some(project.to_string()),
+                None,
+                t,
+            ),
+        );
+    }
 
     if json_output {
         let output = serde_json::json!({

--- a/src/commands/evolve.rs
+++ b/src/commands/evolve.rs
@@ -3,6 +3,7 @@ use rusqlite::Connection;
 use std::collections::HashSet;
 
 use rememora::evolve::{self, MemoryCluster};
+use rememora::models::agent_invocation::{self, Caller};
 use rememora::models::context::{self, ContextRecord, InsertContext};
 use rememora::uri;
 
@@ -139,7 +140,7 @@ pub fn run(
     };
 
     for cluster in clusters.into_iter().take(cluster_count) {
-        let decision = consolidate_cluster(&api_key, &cluster)?;
+        let decision = consolidate_cluster(&api_key, &cluster, conn, project)?;
         let report = apply_decision(conn, &cluster, &decision, dry_run, project)?;
 
         match report.action.as_str() {
@@ -183,7 +184,13 @@ fn load_active_memories(
 }
 
 /// Call the Anthropic API to decide how to consolidate a cluster.
-fn consolidate_cluster(api_key: &str, cluster: &MemoryCluster) -> Result<LlmDecision> {
+fn consolidate_cluster(
+    api_key: &str,
+    cluster: &MemoryCluster,
+    conn: &Connection,
+    project: Option<&str>,
+) -> Result<LlmDecision> {
+    const EVOLVE_MODEL: &str = "claude-haiku-4-5-20251001";
     let mut prompt = String::from(CONSOLIDATION_PROMPT);
 
     for mem in &cluster.memories {
@@ -200,7 +207,7 @@ fn consolidate_cluster(api_key: &str, cluster: &MemoryCluster) -> Result<LlmDeci
     }
 
     let body = serde_json::json!({
-        "model": "claude-haiku-4-5-20251001",
+        "model": EVOLVE_MODEL,
         "max_tokens": 1024,
         "messages": [
             {"role": "user", "content": prompt}
@@ -215,6 +222,18 @@ fn consolidate_cluster(api_key: &str, cluster: &MemoryCluster) -> Result<LlmDeci
         .context("Failed to call Claude API for consolidation")?;
 
     let resp_body: serde_json::Value = resp.into_json().context("Failed to parse API response")?;
+
+    agent_invocation::try_insert(
+        conn,
+        &agent_invocation::record_from_anthropic_api(
+            Caller::Evolve,
+            EVOLVE_MODEL,
+            project.map(str::to_string),
+            None,
+            &resp_body,
+            false,
+        ),
+    );
 
     let content_text = resp_body["content"]
         .as_array()

--- a/src/commands/extract.rs
+++ b/src/commands/extract.rs
@@ -2,8 +2,11 @@ use anyhow::{bail, Context, Result};
 use rusqlite::Connection;
 use std::io::Read;
 
+use rememora::models::agent_invocation::{self, Caller};
 use rememora::models::context::{self, InsertContext};
 use rememora::uri;
+
+const EXTRACT_MODEL: &str = "claude-haiku-4-5-20251001";
 
 const EXTRACT_PROMPT: &str = r#"Extract key memories from the following text. Return a JSON array of objects with these fields:
 - "text": the core fact or knowledge (concise, one sentence)
@@ -58,7 +61,7 @@ pub fn run(
 
     // Call Claude API
     let body = serde_json::json!({
-        "model": "claude-haiku-4-5-20251001",
+        "model": EXTRACT_MODEL,
         "max_tokens": 4096,
         "messages": [
             {"role": "user", "content": prompt}
@@ -73,6 +76,19 @@ pub fn run(
         .context("Failed to call Claude API")?;
 
     let resp_body: serde_json::Value = resp.into_json().context("Failed to parse API response")?;
+
+    // Record telemetry — project for extract is the destination project, if any.
+    agent_invocation::try_insert(
+        conn,
+        &agent_invocation::record_from_anthropic_api(
+            Caller::Extract,
+            EXTRACT_MODEL,
+            project.map(str::to_string),
+            None,
+            &resp_body,
+            false,
+        ),
+    );
 
     // Extract text content from response
     let content_text = resp_body["content"]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -19,3 +19,4 @@ pub mod setup;
 pub mod status;
 pub mod supersede;
 pub mod tui;
+pub mod usage;

--- a/src/commands/tui.rs
+++ b/src/commands/tui.rs
@@ -15,6 +15,7 @@ use rusqlite::Connection;
 use std::io::stdout;
 
 use rememora::hierarchy::{self, ScoredContext};
+use rememora::models::agent_invocation::{self, GroupBy};
 use rememora::models::context::{self, ContextRecord};
 use rememora::models::project;
 use rememora::search;
@@ -72,8 +73,20 @@ struct App {
     search_results: Vec<search::SearchResult>,
     search_state: ListState,
 
+    // Cost footer — total cost + call count over the last 7 days. `None`
+    // means we haven't been able to read the telemetry table (e.g. fresh DB).
+    usage_footer: Option<UsageFooter>,
+
     // Quit flag
     quit: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct UsageFooter {
+    invocations: i64,
+    cost_usd: f64,
+    input_tokens: i64,
+    output_tokens: i64,
 }
 
 impl App {
@@ -107,6 +120,8 @@ impl App {
             memory_state.select(Some(0));
         }
 
+        let usage_footer = load_usage_footer(conn);
+
         Ok(Self {
             focus: Panel::Projects,
             projects,
@@ -121,6 +136,7 @@ impl App {
             search_query: String::new(),
             search_results: Vec::new(),
             search_state: ListState::default(),
+            usage_footer,
             quit: false,
         })
     }
@@ -823,7 +839,7 @@ fn draw_status_bar(f: &mut Frame, app: &App, area: Rect) {
         Panel::Detail => "Detail",
     };
 
-    let bar = Line::from(vec![
+    let mut spans = vec![
         Span::styled(
             format!(" {focus_label} "),
             Style::default()
@@ -832,9 +848,34 @@ fn draw_status_bar(f: &mut Frame, app: &App, area: Rect) {
                 .add_modifier(Modifier::BOLD),
         ),
         Span::styled(hints, Style::default().fg(Color::DarkGray)),
-    ]);
+    ];
 
-    f.render_widget(Paragraph::new(bar), area);
+    if let Some(u) = app.usage_footer {
+        spans.push(Span::styled(
+            format!(
+                " 7d: ${:.4} · {} calls · {}k in / {}k out ",
+                u.cost_usd,
+                u.invocations,
+                u.input_tokens / 1000,
+                u.output_tokens / 1000,
+            ),
+            Style::default().fg(Color::DarkGray),
+        ));
+    }
+
+    f.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+fn load_usage_footer(conn: &Connection) -> Option<UsageFooter> {
+    let since = (chrono::Utc::now() - chrono::Duration::days(7)).to_rfc3339();
+    let rows = agent_invocation::aggregate(conn, Some(&since), GroupBy::Total).ok()?;
+    let row = rows.into_iter().next()?;
+    Some(UsageFooter {
+        invocations: row.invocations,
+        cost_usd: row.cost_usd,
+        input_tokens: row.input_tokens,
+        output_tokens: row.output_tokens,
+    })
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────

--- a/src/commands/usage.rs
+++ b/src/commands/usage.rs
@@ -1,0 +1,177 @@
+//! `rememora usage` — aggregate agent-invocation telemetry.
+//!
+//! Reads from the `agent_invocations` table (migration 004), grouped by
+//! caller / model / project / session / total, since a relative cutoff.
+
+use anyhow::{bail, Context, Result};
+use chrono::{Duration, Utc};
+use rusqlite::Connection;
+
+use rememora::models::agent_invocation::{self, GroupBy, UsageAggregate};
+
+pub struct UsageArgs {
+    pub since: String,
+    pub by: String,
+}
+
+pub fn run(conn: &Connection, args: &UsageArgs, json_output: bool) -> Result<()> {
+    let since = parse_since(&args.since).context("invalid --since value")?;
+    let group_by = parse_group_by(&args.by).context("invalid --by value")?;
+
+    let rows = agent_invocation::aggregate(conn, since.as_deref(), group_by)?;
+
+    if json_output {
+        let out = serde_json::json!({
+            "since": args.since,
+            "by": args.by,
+            "rows": rows,
+        });
+        println!("{}", serde_json::to_string_pretty(&out)?);
+    } else {
+        print_table(&args.by, &rows);
+    }
+
+    Ok(())
+}
+
+/// Turn a relative window like `7d`, `24h`, `30m`, or `all` into an ISO8601
+/// cutoff. `all` returns `None` (no WHERE on ts).
+fn parse_since(s: &str) -> Result<Option<String>> {
+    let s = s.trim();
+    if s.eq_ignore_ascii_case("all") || s.is_empty() {
+        return Ok(None);
+    }
+
+    let (n_str, unit) = s.split_at(
+        s.rfind(|c: char| c.is_ascii_digit())
+            .map(|i| i + 1)
+            .unwrap_or(0),
+    );
+    let n: i64 = n_str.parse().context("expected a number before the unit")?;
+    let duration = match unit.trim() {
+        "m" | "min" | "mins" => Duration::minutes(n),
+        "h" | "hr" | "hrs" => Duration::hours(n),
+        "d" | "day" | "days" => Duration::days(n),
+        "w" | "wk" | "wks" => Duration::weeks(n),
+        other => bail!("unknown time unit `{other}` (use m/h/d/w or `all`)"),
+    };
+
+    let cutoff = Utc::now() - duration;
+    Ok(Some(cutoff.to_rfc3339()))
+}
+
+fn parse_group_by(s: &str) -> Result<GroupBy> {
+    match s.to_ascii_lowercase().as_str() {
+        "total" | "all" => Ok(GroupBy::Total),
+        "caller" => Ok(GroupBy::Caller),
+        "model" => Ok(GroupBy::Model),
+        "project" => Ok(GroupBy::Project),
+        "session" | "parent_session" => Ok(GroupBy::ParentSession),
+        other => bail!("unknown --by `{other}` (expected total|caller|model|project|session)"),
+    }
+}
+
+fn print_table(by: &str, rows: &[UsageAggregate]) {
+    if rows.is_empty() {
+        println!("No agent invocations recorded in this window.");
+        return;
+    }
+
+    let label = match by {
+        "total" | "all" => "scope",
+        other => other,
+    };
+
+    println!(
+        "{:<28} {:>6} {:>6} {:>12} {:>12} {:>14} {:>10} {:>10}",
+        label, "calls", "errs", "in_tok", "out_tok", "cache_read_tok", "avg_ms", "cost_usd"
+    );
+    println!("{}", "-".repeat(112));
+
+    let mut total_invocations = 0i64;
+    let mut total_cost = 0.0f64;
+    let mut total_in = 0i64;
+    let mut total_out = 0i64;
+    let mut total_cache_read = 0i64;
+
+    for row in rows {
+        total_invocations += row.invocations;
+        total_cost += row.cost_usd;
+        total_in += row.input_tokens;
+        total_out += row.output_tokens;
+        total_cache_read += row.cache_read_tokens;
+
+        println!(
+            "{:<28} {:>6} {:>6} {:>12} {:>12} {:>14} {:>10} {:>10}",
+            truncate(&row.bucket, 28),
+            row.invocations,
+            row.errors,
+            row.input_tokens,
+            row.output_tokens,
+            row.cache_read_tokens,
+            row.avg_duration_ms
+                .map(|v| format!("{:.0}", v))
+                .unwrap_or_else(|| "-".into()),
+            format!("{:.4}", row.cost_usd),
+        );
+    }
+
+    if rows.len() > 1 {
+        println!("{}", "-".repeat(112));
+        println!(
+            "{:<28} {:>6} {:>6} {:>12} {:>12} {:>14} {:>10} {:>10}",
+            "TOTAL",
+            total_invocations,
+            "",
+            total_in,
+            total_out,
+            total_cache_read,
+            "",
+            format!("{:.4}", total_cost),
+        );
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let mut out: String = s.chars().take(max.saturating_sub(1)).collect();
+        out.push('…');
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_relative_windows() {
+        assert!(parse_since("7d").unwrap().is_some());
+        assert!(parse_since("24h").unwrap().is_some());
+        assert!(parse_since("30m").unwrap().is_some());
+        assert!(parse_since("2w").unwrap().is_some());
+    }
+
+    #[test]
+    fn all_means_no_cutoff() {
+        assert!(parse_since("all").unwrap().is_none());
+        assert!(parse_since("ALL").unwrap().is_none());
+    }
+
+    #[test]
+    fn rejects_unknown_units() {
+        assert!(parse_since("5x").is_err());
+        assert!(parse_since("abc").is_err());
+    }
+
+    #[test]
+    fn group_by_aliases() {
+        assert_eq!(parse_group_by("caller").unwrap(), GroupBy::Caller);
+        assert_eq!(parse_group_by("Project").unwrap(), GroupBy::Project);
+        assert_eq!(parse_group_by("session").unwrap(), GroupBy::ParentSession);
+        assert_eq!(parse_group_by("total").unwrap(), GroupBy::Total);
+        assert!(parse_group_by("weird").is_err());
+    }
+}

--- a/src/curator.rs
+++ b/src/curator.rs
@@ -4,6 +4,7 @@
 //! no per-token API cost.
 
 use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
 use std::process::Command;
 
 const SIGNAL_GATE_PROMPT: &str = include_str!("../prompts/signal-gate.md");
@@ -19,6 +20,43 @@ pub enum Signal {
     No,
 }
 
+/// Parsed telemetry from `claude -p --output-format json`'s final `result`
+/// entry. Any field may be missing if the subagent errored before emitting it.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SubagentTelemetry {
+    pub model: String,
+    pub child_session_id: Option<String>,
+    pub duration_ms: Option<i64>,
+    pub duration_api_ms: Option<i64>,
+    pub num_turns: Option<i64>,
+    pub input_tokens: Option<i64>,
+    pub output_tokens: Option<i64>,
+    pub cache_read_tokens: Option<i64>,
+    pub cache_creation_tokens: Option<i64>,
+    pub cost_usd: Option<f64>,
+    pub stop_reason: Option<String>,
+    pub terminal_reason: Option<String>,
+    pub is_error: bool,
+    pub permission_denials_json: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SubagentOutput {
+    /// The `result` string from the final `{type:"result"}` entry — what the
+    /// agent actually replied with.
+    pub text: String,
+    pub telemetry: SubagentTelemetry,
+}
+
+/// Signal-gate outcome with telemetry for the Haiku call.
+#[derive(Debug)]
+pub struct SignalGateResult {
+    pub signal: Signal,
+    /// `None` when the gate short-circuited (transcript too short) — no
+    /// subagent call, nothing to record.
+    pub telemetry: Option<SubagentTelemetry>,
+}
+
 /// Result of a full curation run.
 #[derive(Debug)]
 pub struct CurationResult {
@@ -28,25 +66,35 @@ pub struct CurationResult {
     pub curator_output: Option<String>,
     /// Whether this was a dry run (no actual curation performed).
     pub dry_run: bool,
+    /// Telemetry for the Sonnet curator call.
+    pub telemetry: Option<SubagentTelemetry>,
 }
 
 /// Check whether a transcript has signal worth curating.
 ///
 /// Uses Haiku via subagent for a fast YES/NO classification.
-pub fn signal_gate(transcript: &str) -> Result<Signal> {
+pub fn signal_gate(transcript: &str) -> Result<SignalGateResult> {
     if transcript.len() < MIN_TRANSCRIPT_CHARS {
-        return Ok(Signal::No);
+        return Ok(SignalGateResult {
+            signal: Signal::No,
+            telemetry: None,
+        });
     }
 
     let prompt = SIGNAL_GATE_PROMPT.replace("{transcript}", transcript);
     let output = call_subagent(&prompt, "haiku")?;
 
-    let answer = output.trim().to_uppercase();
-    if answer.contains("YES") {
-        Ok(Signal::Yes)
+    let answer = output.text.trim().to_uppercase();
+    let signal = if answer.contains("YES") {
+        Signal::Yes
     } else {
-        Ok(Signal::No)
-    }
+        Signal::No
+    };
+
+    Ok(SignalGateResult {
+        signal,
+        telemetry: Some(output.telemetry),
+    })
 }
 
 /// Run the full AUDN curation cycle on a transcript.
@@ -71,8 +119,9 @@ pub fn curate(transcript: &str, project: &str, dry_run: bool) -> Result<Curation
 
     Ok(CurationResult {
         signal: Signal::Yes,
-        curator_output: Some(output),
+        curator_output: Some(output.text),
         dry_run,
+        telemetry: Some(output.telemetry),
     })
 }
 
@@ -81,7 +130,10 @@ pub fn curate(transcript: &str, project: &str, dry_run: bool) -> Result<Curation
 /// Uses `--tools Bash` to restrict the subagent to only the Bash tool
 /// (prevents file writes to auto-memory). Grants scoped bash access via
 /// `--allowedTools` so it can run `rememora` CLI commands without prompting.
-pub fn call_subagent(prompt: &str, model: &str) -> Result<String> {
+///
+/// Uses `--output-format json` so we can capture usage, cost, and duration
+/// telemetry alongside the agent's text reply.
+pub fn call_subagent(prompt: &str, model: &str) -> Result<SubagentOutput> {
     let output = build_subagent_command(prompt, model)
         .output()
         .context("Failed to run 'claude' CLI. Is Claude Code installed?")?;
@@ -91,7 +143,8 @@ pub fn call_subagent(prompt: &str, model: &str) -> Result<String> {
         bail!("claude -p failed (exit {}): {stderr}", output.status);
     }
 
-    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_subagent_output(&stdout, model)
 }
 
 fn build_subagent_command(prompt: &str, model: &str) -> Command {
@@ -101,6 +154,8 @@ fn build_subagent_command(prompt: &str, model: &str) -> Command {
         prompt,
         "--model",
         model,
+        "--output-format",
+        "json",
         "--tools",
         "Bash",
         "--allowedTools",
@@ -112,6 +167,79 @@ fn build_subagent_command(prompt: &str, model: &str) -> Command {
     cmd
 }
 
+/// Parse `claude -p --output-format json` stdout.
+///
+/// Output is a JSON array of event objects; we walk it to find the final
+/// `{type:"result"}` entry which carries `result`, `usage`, `total_cost_usd`,
+/// `duration_ms`, `stop_reason`, `terminal_reason`, `permission_denials`.
+pub fn parse_subagent_output(stdout: &str, model: &str) -> Result<SubagentOutput> {
+    let events: serde_json::Value =
+        serde_json::from_str(stdout.trim()).context("claude -p returned non-JSON output")?;
+
+    let array = events
+        .as_array()
+        .context("claude -p JSON was not an array")?;
+
+    let result_entry = array
+        .iter()
+        .rev()
+        .find(|v| v.get("type").and_then(|t| t.as_str()) == Some("result"))
+        .context("claude -p JSON stream had no {type:\"result\"} entry")?;
+
+    let text = result_entry
+        .get("result")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let usage = result_entry.get("usage");
+    let telemetry = SubagentTelemetry {
+        model: result_entry
+            .get("modelUsage")
+            .and_then(|mu| mu.as_object())
+            .and_then(|obj| obj.keys().next().cloned())
+            .unwrap_or_else(|| model.to_string()),
+        child_session_id: result_entry
+            .get("session_id")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        duration_ms: result_entry.get("duration_ms").and_then(|v| v.as_i64()),
+        duration_api_ms: result_entry.get("duration_api_ms").and_then(|v| v.as_i64()),
+        num_turns: result_entry.get("num_turns").and_then(|v| v.as_i64()),
+        input_tokens: usage.and_then(|u| u.get("input_tokens")).and_then(|v| v.as_i64()),
+        output_tokens: usage
+            .and_then(|u| u.get("output_tokens"))
+            .and_then(|v| v.as_i64()),
+        cache_read_tokens: usage
+            .and_then(|u| u.get("cache_read_input_tokens"))
+            .and_then(|v| v.as_i64()),
+        cache_creation_tokens: usage
+            .and_then(|u| u.get("cache_creation_input_tokens"))
+            .and_then(|v| v.as_i64()),
+        cost_usd: result_entry
+            .get("total_cost_usd")
+            .and_then(|v| v.as_f64()),
+        stop_reason: result_entry
+            .get("stop_reason")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        terminal_reason: result_entry
+            .get("terminal_reason")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        is_error: result_entry
+            .get("is_error")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        permission_denials_json: result_entry
+            .get("permission_denials")
+            .map(|v| v.to_string())
+            .filter(|s| s != "[]" && s != "null"),
+    };
+
+    Ok(SubagentOutput { text, telemetry })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -121,7 +249,8 @@ mod tests {
         // Transcripts below MIN_TRANSCRIPT_CHARS should return No without calling subagent
         let short = "user: hello\nassistant: hi";
         let result = signal_gate(short).unwrap();
-        assert_eq!(result, Signal::No);
+        assert_eq!(result.signal, Signal::No);
+        assert!(result.telemetry.is_none());
     }
 
     #[test]
@@ -155,5 +284,86 @@ mod tests {
             .find_map(|(key, value)| (key == "REMEMORA_CURATE_CHILD").then_some(value));
 
         assert_eq!(env_value.flatten(), Some(std::ffi::OsStr::new("1")));
+    }
+
+    #[test]
+    fn test_subagent_command_requests_json_output() {
+        let cmd = build_subagent_command("p", "haiku");
+        let args: Vec<&std::ffi::OsStr> = cmd.get_args().collect();
+        // Args appear pairwise: ["--output-format","json"]
+        let pos = args
+            .iter()
+            .position(|a| *a == std::ffi::OsStr::new("--output-format"));
+        assert!(pos.is_some(), "--output-format flag missing");
+        assert_eq!(args[pos.unwrap() + 1], std::ffi::OsStr::new("json"));
+    }
+
+    #[test]
+    fn test_parse_subagent_output_full() {
+        let stdout = r#"[
+            {"type":"system","subtype":"init","session_id":"s1"},
+            {"type":"result","subtype":"success","is_error":false,"duration_ms":3208,
+             "duration_api_ms":2693,"num_turns":1,"result":"Hey there, friend!",
+             "stop_reason":"end_turn","session_id":"s1","total_cost_usd":0.0135815,
+             "usage":{"input_tokens":10,"cache_creation_input_tokens":6366,
+                      "cache_read_input_tokens":51240,"output_tokens":98},
+             "modelUsage":{"claude-haiku-4-5-20251001":{"inputTokens":10,"outputTokens":98}},
+             "permission_denials":[],"terminal_reason":"completed"}
+        ]"#;
+        let out = parse_subagent_output(stdout, "haiku").unwrap();
+        assert_eq!(out.text, "Hey there, friend!");
+        let t = out.telemetry;
+        assert_eq!(t.model, "claude-haiku-4-5-20251001");
+        assert_eq!(t.child_session_id.as_deref(), Some("s1"));
+        assert_eq!(t.duration_ms, Some(3208));
+        assert_eq!(t.input_tokens, Some(10));
+        assert_eq!(t.output_tokens, Some(98));
+        assert_eq!(t.cache_read_tokens, Some(51240));
+        assert_eq!(t.cache_creation_tokens, Some(6366));
+        assert_eq!(t.cost_usd, Some(0.0135815));
+        assert_eq!(t.stop_reason.as_deref(), Some("end_turn"));
+        assert_eq!(t.terminal_reason.as_deref(), Some("completed"));
+        assert!(!t.is_error);
+        assert!(t.permission_denials_json.is_none()); // filtered out "[]"
+    }
+
+    #[test]
+    fn test_parse_subagent_output_missing_fields() {
+        // A minimal result entry — parser must not panic, just leave Nones.
+        let stdout = r#"[{"type":"result","result":"ok"}]"#;
+        let out = parse_subagent_output(stdout, "sonnet").unwrap();
+        assert_eq!(out.text, "ok");
+        assert_eq!(out.telemetry.model, "sonnet"); // falls back to the model we asked for
+        assert!(out.telemetry.input_tokens.is_none());
+        assert!(out.telemetry.cost_usd.is_none());
+    }
+
+    #[test]
+    fn test_parse_subagent_output_records_permission_denials() {
+        let stdout = r#"[{"type":"result","result":"","permission_denials":[{"tool":"Bash","input":"rm -rf /"}]}]"#;
+        let out = parse_subagent_output(stdout, "haiku").unwrap();
+        assert!(out.telemetry.permission_denials_json.is_some());
+        assert!(out
+            .telemetry
+            .permission_denials_json
+            .unwrap()
+            .contains("rm -rf"));
+    }
+
+    #[test]
+    fn test_parse_subagent_output_error_bubbles_on_missing_result() {
+        let stdout = r#"[{"type":"system","subtype":"init"}]"#;
+        let err = parse_subagent_output(stdout, "haiku").unwrap_err();
+        assert!(err.to_string().contains("no {type:\"result\"}"));
+    }
+
+    #[test]
+    fn test_parse_subagent_output_picks_last_result_if_multiple() {
+        let stdout = r#"[
+            {"type":"result","result":"first"},
+            {"type":"result","result":"last"}
+        ]"#;
+        let out = parse_subagent_output(stdout, "haiku").unwrap();
+        assert_eq!(out.text, "last");
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 const MIGRATION_001: &str = include_str!("migrations/001_initial.sql");
 const MIGRATION_002: &str = include_str!("migrations/002_embeddings.sql");
 const MIGRATION_003: &str = include_str!("migrations/003_curator.sql");
+const MIGRATION_004: &str = include_str!("migrations/004_agent_invocations.sql");
 
 /// Register sqlite-vec extension before opening connections.
 /// Must be called before any Connection::open calls.
@@ -118,6 +119,20 @@ fn migrate(conn: &Connection) -> Result<()> {
         conn.execute_batch(MIGRATION_003)?;
         conn.execute(
             "INSERT INTO _migrations (name, applied_at) VALUES ('003_curator', datetime('now'))",
+            [],
+        )?;
+    }
+
+    let applied_004: bool = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM _migrations WHERE name = '004_agent_invocations')",
+        [],
+        |row| row.get(0),
+    )?;
+
+    if !applied_004 {
+        conn.execute_batch(MIGRATION_004)?;
+        conn.execute(
+            "INSERT INTO _migrations (name, applied_at) VALUES ('004_agent_invocations', datetime('now'))",
             [],
         )?;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -336,6 +336,17 @@ enum Commands {
         format: String,
     },
 
+    /// Aggregate agent-invocation telemetry (tokens, cost, duration).
+    Usage {
+        /// Window to aggregate over. Accepts e.g. `7d`, `24h`, `30m`, `all`.
+        #[arg(long, default_value = "7d")]
+        since: String,
+
+        /// How to group: `total`, `caller`, `model`, `project`, `session`.
+        #[arg(long, default_value = "caller")]
+        by: String,
+    },
+
     /// Launch the Rememora Desktop app (Tauri)
     Desktop,
 }
@@ -723,5 +734,11 @@ fn main() -> Result<()> {
         Commands::Export { project, format } => {
             commands::export::run(&conn, project.as_deref(), &format)
         }
+
+        Commands::Usage { since, by } => commands::usage::run(
+            &conn,
+            &commands::usage::UsageArgs { since, by },
+            cli.json,
+        ),
     }
 }

--- a/src/migrations/001_initial.sql
+++ b/src/migrations/001_initial.sql
@@ -1,5 +1,24 @@
--- Rememora schema v1
--- Unified context database following OpenViking's entity model
+-- ─── Migration 001: initial schema ──────────────────────────────────────────
+-- Establishes the core of Rememora: one unified `contexts` table holding every
+-- memory, project, resource, and skill under a single `rememora://` URI tree.
+-- Everything else in the DB (sessions, relations, embeddings, analytics) joins
+-- back to this table.
+--
+-- What this migration creates:
+--   * `contexts` — the polymorphic entity table. `context_type` discriminates
+--     between memory/resource/skill/project; `category` is the 6-way memory
+--     taxonomy (preference/entity/decision/event/case/pattern).
+--   * `contexts_fts` + triggers — FTS5 virtual table mirroring name/abstract/
+--     overview/content for BM25 search. Triggers keep it in sync on insert/
+--     update/delete.
+--   * `sessions` — cross-agent session lifecycle (start/end/transfer chains).
+--   * `relations` — typed edges between contexts for knowledge graphing.
+--   * `projects` — registered project roots (name, path, description).
+--
+-- Why one table instead of many: OpenViking's lesson — polymorphic rows with
+-- a URI hierarchy and tiered loading (L0 abstract / L1 overview / L2 content)
+-- outperforms a table-per-kind design for long-tail entity types, and keeps
+-- hotness/importance ranking uniform across all memory categories.
 
 CREATE TABLE IF NOT EXISTS contexts (
     id          TEXT PRIMARY KEY,

--- a/src/migrations/002_embeddings.sql
+++ b/src/migrations/002_embeddings.sql
@@ -1,5 +1,17 @@
--- Embedding storage for vector search
--- Stores f32 embeddings as little-endian BLOB alongside context references
+-- ─── Migration 002: embedding storage ───────────────────────────────────────
+-- Parks vector embeddings for each context so vector search can run alongside
+-- FTS5/BM25. Storage-only — the actual similarity query lives in sqlite-vec's
+-- virtual table (`vec_contexts`, created in db.rs when the `embed-candle`
+-- feature is enabled).
+--
+-- Shape: one row per context. `embedding` is a packed little-endian f32 BLOB
+-- (dimensions × 4 bytes); `dimensions` and `model_name` let us detect and
+-- migrate when the backend swaps embedders.
+--
+-- Why a separate table instead of a column on `contexts`: embeddings are big
+-- (~1.5 KB for a 384-d f32), feature-gated, and have their own lifecycle
+-- (re-embed on model change). Keeping them out of the main row avoids bloat
+-- on every SELECT against `contexts`.
 
 CREATE TABLE IF NOT EXISTS context_embeddings (
     context_id  TEXT PRIMARY KEY REFERENCES contexts(id) ON DELETE CASCADE,

--- a/src/migrations/003_curator.sql
+++ b/src/migrations/003_curator.sql
@@ -1,4 +1,20 @@
--- Curator infrastructure: watermarks, curation log, consolidation runs
+-- ─── Migration 003: curator infrastructure ──────────────────────────────────
+-- Backs the Stop-hook curator's three responsibilities:
+--   1. *Incremental* curation — never re-feed the signal gate or curator with
+--      content it has already seen. `watermarks` stores the byte offset we
+--      have consumed up to for each Claude Code session JSONL, keyed by file
+--      path. On every Stop hook we `parse_file(path, watermark.byte_offset)`
+--      and only the delta reaches the subagent.
+--   2. *Audit trail* — `curator_log` records every action the curator took
+--      (add/update/delete/noop) with the reason and the model that decided.
+--      Makes it possible to debug "why did the curator change this memory".
+--   3. *Consolidation tracking* — `consolidation_runs` brackets each evolve/
+--      merge pass with before/after counts, cluster count, and the trigger
+--      source, so we can tell consolidation cron runs from manual invocations.
+--
+-- Watermark advances on Signal::No too (see `src/commands/curate.rs`), which
+-- is what makes the Haiku signal gate cheap — it never re-evaluates stale
+-- turns.
 
 -- Tracks byte offset per session JSONL file for incremental curation
 CREATE TABLE IF NOT EXISTS watermarks (

--- a/src/migrations/004_agent_invocations.sql
+++ b/src/migrations/004_agent_invocations.sql
@@ -1,0 +1,53 @@
+-- ─── Migration 004: agent-invocation telemetry ──────────────────────────────
+-- Captures one row per LLM call Rememora makes, so users can answer questions
+-- like "how much did the curator cost this week", "which caller dominates my
+-- spend", "is the Haiku signal gate paying for itself". Without this table
+-- every subagent invocation is a black box.
+--
+-- Rows are inserted from four sites:
+--   * `src/curator.rs::call_subagent`      — `claude -p` signal-gate + curator
+--   * `src/commands/extract.rs`            — direct Anthropic API
+--   * `src/commands/evolve.rs`             — direct Anthropic API
+--   * `src/commands/agent_run.rs`          — `claude -p` for GitHub dispatch
+--
+-- Column shape mirrors what `claude -p --output-format json` returns in its
+-- final `{type:"result"}` entry plus what the Anthropic REST API puts on
+-- `response.usage`. `cost_usd` is taken verbatim from the provider — we don't
+-- re-derive from token counts because pricing changes. `parent_session` ties
+-- a curator invocation back to the Rememora session that triggered it;
+-- `child_session` is the `claude -p` subagent's own session_id (useful for
+-- pulling its transcript when debugging permission denials).
+--
+-- Indexes are cost-ordered for the three queries `rememora usage` actually
+-- runs: "latest N", "per-project since X", "per-caller since X".
+
+CREATE TABLE IF NOT EXISTS agent_invocations (
+    id                      TEXT PRIMARY KEY,
+    ts                      TEXT NOT NULL,
+    caller                  TEXT NOT NULL,
+    model                   TEXT NOT NULL,
+    project                 TEXT,
+    parent_session          TEXT,
+    child_session           TEXT,
+    duration_ms             INTEGER,
+    duration_api_ms         INTEGER,
+    num_turns               INTEGER,
+    input_tokens            INTEGER,
+    output_tokens           INTEGER,
+    cache_read_tokens       INTEGER,
+    cache_creation_tokens   INTEGER,
+    cost_usd                REAL,
+    stop_reason             TEXT,
+    terminal_reason         TEXT,
+    is_error                INTEGER NOT NULL DEFAULT 0,
+    permission_denials_json TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_invocations_ts
+    ON agent_invocations(ts DESC);
+CREATE INDEX IF NOT EXISTS idx_agent_invocations_project_ts
+    ON agent_invocations(project, ts DESC);
+CREATE INDEX IF NOT EXISTS idx_agent_invocations_caller_ts
+    ON agent_invocations(caller, ts DESC);
+CREATE INDEX IF NOT EXISTS idx_agent_invocations_parent_session
+    ON agent_invocations(parent_session);

--- a/src/models/agent_invocation.rs
+++ b/src/models/agent_invocation.rs
@@ -1,0 +1,339 @@
+//! Per-invocation telemetry for every LLM call (subagent or direct API).
+//!
+//! Writers land here from four places:
+//! - `curator::call_subagent` (signal_gate + curator)
+//! - `commands::extract` (direct Anthropic API)
+//! - `commands::evolve` (direct Anthropic API)
+//! - `commands::agent_run` (`claude -p` for GitHub issue dispatch)
+//!
+//! Readers are `rememora usage` (aggregation) and the TUI cost tile.
+
+use anyhow::Result;
+use rusqlite::{params, Connection};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Caller {
+    SignalGate,
+    Curator,
+    Extract,
+    Evolve,
+    Consolidate,
+    AgentRun,
+}
+
+impl Caller {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Caller::SignalGate => "signal_gate",
+            Caller::Curator => "curator",
+            Caller::Extract => "extract",
+            Caller::Evolve => "evolve",
+            Caller::Consolidate => "consolidate",
+            Caller::AgentRun => "agent_run",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct InvocationRecord {
+    pub caller: &'static str,
+    pub model: String,
+    pub project: Option<String>,
+    pub parent_session: Option<String>,
+    pub child_session: Option<String>,
+    pub duration_ms: Option<i64>,
+    pub duration_api_ms: Option<i64>,
+    pub num_turns: Option<i64>,
+    pub input_tokens: Option<i64>,
+    pub output_tokens: Option<i64>,
+    pub cache_read_tokens: Option<i64>,
+    pub cache_creation_tokens: Option<i64>,
+    pub cost_usd: Option<f64>,
+    pub stop_reason: Option<String>,
+    pub terminal_reason: Option<String>,
+    pub is_error: bool,
+    pub permission_denials_json: Option<String>,
+}
+
+/// Build an `InvocationRecord` from subagent telemetry plus the caller's
+/// surrounding context (caller kind, project, parent session).
+pub fn record_from_subagent(
+    caller: Caller,
+    project: Option<String>,
+    parent_session: Option<String>,
+    telemetry: &crate::curator::SubagentTelemetry,
+) -> InvocationRecord {
+    InvocationRecord {
+        caller: caller.as_str(),
+        model: telemetry.model.clone(),
+        project,
+        parent_session,
+        child_session: telemetry.child_session_id.clone(),
+        duration_ms: telemetry.duration_ms,
+        duration_api_ms: telemetry.duration_api_ms,
+        num_turns: telemetry.num_turns,
+        input_tokens: telemetry.input_tokens,
+        output_tokens: telemetry.output_tokens,
+        cache_read_tokens: telemetry.cache_read_tokens,
+        cache_creation_tokens: telemetry.cache_creation_tokens,
+        cost_usd: telemetry.cost_usd,
+        stop_reason: telemetry.stop_reason.clone(),
+        terminal_reason: telemetry.terminal_reason.clone(),
+        is_error: telemetry.is_error,
+        permission_denials_json: telemetry.permission_denials_json.clone(),
+    }
+}
+
+/// Build an `InvocationRecord` from an Anthropic Messages API response body.
+///
+/// Looks at `response.usage.{input_tokens,output_tokens,cache_*}`. Cost is
+/// left `None` — the API doesn't return it and pricing drifts, so we prefer
+/// truth over an unmaintained price table.
+pub fn record_from_anthropic_api(
+    caller: Caller,
+    model: &str,
+    project: Option<String>,
+    parent_session: Option<String>,
+    resp_body: &serde_json::Value,
+    is_error: bool,
+) -> InvocationRecord {
+    let usage = resp_body.get("usage");
+    InvocationRecord {
+        caller: caller.as_str(),
+        model: model.to_string(),
+        project,
+        parent_session,
+        child_session: None,
+        duration_ms: None,
+        duration_api_ms: None,
+        num_turns: Some(1),
+        input_tokens: usage.and_then(|u| u.get("input_tokens")).and_then(|v| v.as_i64()),
+        output_tokens: usage
+            .and_then(|u| u.get("output_tokens"))
+            .and_then(|v| v.as_i64()),
+        cache_read_tokens: usage
+            .and_then(|u| u.get("cache_read_input_tokens"))
+            .and_then(|v| v.as_i64()),
+        cache_creation_tokens: usage
+            .and_then(|u| u.get("cache_creation_input_tokens"))
+            .and_then(|v| v.as_i64()),
+        cost_usd: None,
+        stop_reason: resp_body
+            .get("stop_reason")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        terminal_reason: None,
+        is_error,
+        permission_denials_json: None,
+    }
+}
+
+pub fn insert(conn: &Connection, record: &InvocationRecord) -> Result<String> {
+    let id = ulid::Ulid::new().to_string();
+    let ts = chrono::Utc::now().to_rfc3339();
+
+    conn.execute(
+        "INSERT INTO agent_invocations (
+            id, ts, caller, model, project, parent_session, child_session,
+            duration_ms, duration_api_ms, num_turns,
+            input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
+            cost_usd, stop_reason, terminal_reason, is_error, permission_denials_json
+        ) VALUES (
+            ?1, ?2, ?3, ?4, ?5, ?6, ?7,
+            ?8, ?9, ?10,
+            ?11, ?12, ?13, ?14,
+            ?15, ?16, ?17, ?18, ?19
+        )",
+        params![
+            id,
+            ts,
+            record.caller,
+            record.model,
+            record.project,
+            record.parent_session,
+            record.child_session,
+            record.duration_ms,
+            record.duration_api_ms,
+            record.num_turns,
+            record.input_tokens,
+            record.output_tokens,
+            record.cache_read_tokens,
+            record.cache_creation_tokens,
+            record.cost_usd,
+            record.stop_reason,
+            record.terminal_reason,
+            record.is_error as i64,
+            record.permission_denials_json,
+        ],
+    )?;
+
+    Ok(id)
+}
+
+/// Best-effort insert that never raises.
+///
+/// Telemetry must not break the caller. If the DB is unreachable or the
+/// schema drifted, swallow the error and return without propagating.
+pub fn try_insert(conn: &Connection, record: &InvocationRecord) {
+    if let Err(e) = insert(conn, record) {
+        eprintln!("warn: agent_invocation insert failed: {e}");
+    }
+}
+
+// ── Aggregation ─────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageAggregate {
+    pub bucket: String,
+    pub invocations: i64,
+    pub errors: i64,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub cache_creation_tokens: i64,
+    pub cost_usd: f64,
+    pub avg_duration_ms: Option<f64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GroupBy {
+    Total,
+    Caller,
+    Model,
+    Project,
+    ParentSession,
+}
+
+impl GroupBy {
+    fn column(self) -> Option<&'static str> {
+        match self {
+            GroupBy::Total => None,
+            GroupBy::Caller => Some("caller"),
+            GroupBy::Model => Some("model"),
+            GroupBy::Project => Some("project"),
+            GroupBy::ParentSession => Some("parent_session"),
+        }
+    }
+}
+
+/// Aggregate usage since an ISO8601 cutoff (inclusive).
+///
+/// `since` is `NULL`-safe: pass `None` to aggregate all history.
+pub fn aggregate(
+    conn: &Connection,
+    since: Option<&str>,
+    group_by: GroupBy,
+) -> Result<Vec<UsageAggregate>> {
+    let (bucket_expr, group_clause) = match group_by.column() {
+        None => ("'total'", String::new()),
+        Some(col) => (col, format!(" GROUP BY {col}")),
+    };
+
+    let sql = format!(
+        "SELECT
+            COALESCE({bucket_expr}, 'unknown') AS bucket,
+            COUNT(*) AS invocations,
+            SUM(CASE WHEN is_error = 1 THEN 1 ELSE 0 END) AS errors,
+            COALESCE(SUM(input_tokens), 0)          AS input_tokens,
+            COALESCE(SUM(output_tokens), 0)         AS output_tokens,
+            COALESCE(SUM(cache_read_tokens), 0)     AS cache_read_tokens,
+            COALESCE(SUM(cache_creation_tokens), 0) AS cache_creation_tokens,
+            COALESCE(SUM(cost_usd), 0.0)            AS cost_usd,
+            AVG(duration_ms)                        AS avg_duration_ms
+         FROM agent_invocations
+         WHERE (?1 IS NULL OR ts >= ?1){group_clause}
+         ORDER BY cost_usd DESC"
+    );
+
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt
+        .query_map(params![since], |row| {
+            Ok(UsageAggregate {
+                bucket: row.get(0)?,
+                invocations: row.get(1)?,
+                errors: row.get(2)?,
+                input_tokens: row.get(3)?,
+                output_tokens: row.get(4)?,
+                cache_read_tokens: row.get(5)?,
+                cache_creation_tokens: row.get(6)?,
+                cost_usd: row.get(7)?,
+                avg_duration_ms: row.get(8)?,
+            })
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+
+    Ok(rows)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db;
+
+    fn sample(caller: Caller, model: &str, cost: f64) -> InvocationRecord {
+        InvocationRecord {
+            caller: caller.as_str(),
+            model: model.into(),
+            input_tokens: Some(10),
+            output_tokens: Some(20),
+            cache_read_tokens: Some(100),
+            cost_usd: Some(cost),
+            duration_ms: Some(1500),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn insert_and_aggregate_total() {
+        let conn = db::open_memory().unwrap();
+        insert(&conn, &sample(Caller::Curator, "sonnet", 0.05)).unwrap();
+        insert(&conn, &sample(Caller::SignalGate, "haiku", 0.01)).unwrap();
+
+        let totals = aggregate(&conn, None, GroupBy::Total).unwrap();
+        assert_eq!(totals.len(), 1);
+        assert_eq!(totals[0].invocations, 2);
+        assert!((totals[0].cost_usd - 0.06).abs() < 1e-9);
+        assert_eq!(totals[0].input_tokens, 20);
+        assert_eq!(totals[0].output_tokens, 40);
+    }
+
+    #[test]
+    fn aggregate_by_caller_sorts_by_cost() {
+        let conn = db::open_memory().unwrap();
+        insert(&conn, &sample(Caller::SignalGate, "haiku", 0.01)).unwrap();
+        insert(&conn, &sample(Caller::Curator, "sonnet", 0.50)).unwrap();
+        insert(&conn, &sample(Caller::Curator, "sonnet", 0.30)).unwrap();
+
+        let by_caller = aggregate(&conn, None, GroupBy::Caller).unwrap();
+        assert_eq!(by_caller.len(), 2);
+        assert_eq!(by_caller[0].bucket, "curator");
+        assert!((by_caller[0].cost_usd - 0.80).abs() < 1e-9);
+        assert_eq!(by_caller[1].bucket, "signal_gate");
+    }
+
+    #[test]
+    fn since_filter_excludes_old_rows() {
+        let conn = db::open_memory().unwrap();
+        // Directly insert with a stale ts
+        conn.execute(
+            "INSERT INTO agent_invocations (id, ts, caller, model, cost_usd, is_error)
+             VALUES ('old', '1999-01-01T00:00:00Z', 'curator', 'sonnet', 0.10, 0)",
+            [],
+        )
+        .unwrap();
+        insert(&conn, &sample(Caller::Curator, "sonnet", 0.20)).unwrap();
+
+        let recent = aggregate(&conn, Some("2020-01-01T00:00:00Z"), GroupBy::Total).unwrap();
+        assert_eq!(recent[0].invocations, 1);
+        assert!((recent[0].cost_usd - 0.20).abs() < 1e-9);
+    }
+
+    #[test]
+    fn try_insert_does_not_panic_on_bad_schema() {
+        // Open an in-memory DB then drop the table — try_insert should log and return.
+        let conn = db::open_memory().unwrap();
+        conn.execute("DROP TABLE agent_invocations", []).unwrap();
+        try_insert(&conn, &sample(Caller::Curator, "sonnet", 0.1));
+    }
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,3 +1,4 @@
+pub mod agent_invocation;
 pub mod context;
 pub mod project;
 pub mod relation;

--- a/tests/test_db.rs
+++ b/tests/test_db.rs
@@ -71,5 +71,5 @@ fn test_migrations_idempotent() {
     let count: i64 = conn
         .query_row("SELECT COUNT(*) FROM _migrations", [], |r| r.get(0))
         .unwrap();
-    assert_eq!(count, 3);
+    assert_eq!(count, 4);
 }


### PR DESCRIPTION
Closes (partially) #68.

## Summary
- Every `claude -p` and direct Anthropic API call Rememora makes now writes one row to a new `agent_invocations` table capturing tokens (in/out + both cache tiers), cost, duration, stop/terminal reason, permission denials, and child session id.
- New `rememora usage [--since 7d] [--by caller|model|project|session]` aggregates the table into a readable rollup (or JSON).
- TUI gets a 7-day cost footer tile (`7d: \$X.XXXX · N calls · Yk in / Zk out`).
- All four migrations gained header comments explaining what they do in practice.

## Why

Before this, every subagent invocation was a black box — no way to answer "how much did the curator cost this week", "is the Haiku signal gate paying for itself", or "which caller dominates my spend". `claude -p --output-format json` already returns full telemetry in its final `{type:\"result\"}` entry; we were just throwing it away.

## Scope

Instrumented:
- `curator::call_subagent` — `signal_gate` + `curator` (Haiku + Sonnet)
- `commands/extract.rs` — direct Anthropic API
- `commands/evolve.rs` — direct Anthropic API
- `commands/consolidate.rs` — Sonnet via `call_subagent`

Deferred to a follow-up:
- `commands/agent_run.rs` — would require threading a `Connection` through the worktree loop. Tracked under the same issue.

## Design notes

- **Same DB, new table.** Analytics live alongside `watermarks`, `curator_log`, `consolidation_runs` in `~/.rememora/rememora.db`. Precedent already set. Free joins to `sessions`/`projects`. ~15 MB/year of volume — trivial.
- **`try_insert` never fails the caller.** If telemetry can't be written (schema drift, exotic failure), we log and keep going. Telemetry must never break curation.
- **Trust `total_cost_usd` from `claude -p`.** For the direct-API paths we leave `cost_usd` NULL rather than re-derive from a drifting price table; the usage table still shows tokens.
- **`--output-format json` on the subagent** is what unlocks everything; we parse the last `{type:\"result\"}` entry so even an error partial stream degrades gracefully.

## Schema

\`\`\`sql
CREATE TABLE agent_invocations (
  id, ts, caller, model, project, parent_session, child_session,
  duration_ms, duration_api_ms, num_turns,
  input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
  cost_usd, stop_reason, terminal_reason, is_error, permission_denials_json
);
-- + 4 indexes for the queries \`rememora usage\` runs.
\`\`\`

## Test plan
- [x] \`cargo test\` — 130+ tests pass including new units (parser + aggregator + since-window parser + fallback behavior for missing fields / error cases / bad schema).
- [x] \`cargo clippy -- -D warnings\` clean.
- [x] Migration idempotency test updated to expect 4 migrations.
- [ ] Manual: after install, run a curate pass, then \`rememora usage\` and confirm rows land.
- [ ] Manual: launch TUI, confirm footer renders a cost summary.

## Follow-ups
- Wire `agent_run.rs` into the same telemetry pipeline (needs \`Connection\` plumbing).
- Add a simple retention job (\`DELETE FROM agent_invocations WHERE ts < date('now','-365 days')\`) — one line, skipped for now.
- Optional cost derivation for direct-API calls via a pricing table (or defer to Anthropic adding usage.cost to the response).