### PR TITLE
chore(release): v0.4.0 and plugin v1.1.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "rememora",
       "source": "./plugin",
       "description": "Persistent cross-agent memory for Claude Code. Auto-saves decisions, bug fixes, and patterns. Searches memory before implementations.",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "author": {
         "name": "Rememora"
       },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2582,7 +2582,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rememora"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rememora"
-version = "0.3.3"
+version = "0.4.0"
 edition = "2021"
 description = "Cross-agent memory system for AI coding assistants"
 license = "MIT"


### PR DESCRIPTION
## Summary
- bump Rust CLI crate from 0.3.3 to 0.4.0
- bump Cargo.lock package metadata to 0.4.0
- bump Claude plugin marketplace metadata from 1.1.0 to 1.1.1

## Release contents
- #67: fully detach Stop-hook curate subprocess so Claude Code is not blocked by inherited stdout/stderr FDs
- #69: agent invocation telemetry table/writer, `rememora usage`, and TUI 7-day cost footer

## Validation
- `git diff --check`
- `cargo test`
- `cargo clippy -- -D warnings`