### PR TITLE
feat(agent_run): record agent_invocations row per claude -p attempt (#70)

### DIFF
--- a/src/commands/agent_run.rs
+++ b/src/commands/agent_run.rs
@@ -3,6 +3,10 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use rememora::curator::{parse_subagent_output, SubagentOutput};
+use rememora::db;
+use rememora::models::agent_invocation::{self, Caller};
+
 // GitHub Project board IDs for Rememora/rememora project #3
 const PROJECT_ID: &str = "PVT_kwDOCB405M4BSdN1";
 const STATUS_FIELD_ID: &str = "PVTSSF_lADOCB405M4BSdN1zg__B7M";
@@ -71,6 +75,17 @@ pub fn run(args: &AgentRunArgs) -> Result<()> {
     let session_id = start_session(args.issue, &issue.title)?;
     println!("Rememora session: {session_id}");
 
+    // Open a DB handle so we can record one `agent_invocations` row per
+    // `claude -p` attempt. Non-fatal if the DB is unavailable — telemetry
+    // must not block the agent run.
+    let conn = db::open(&db::default_db_path()).ok();
+    if conn.is_none() {
+        eprintln!(
+            "warn: could not open rememora DB at {}; agent_invocations will not be recorded",
+            db::default_db_path().display()
+        );
+    }
+
     // 5. Quality loop: run claude, check quality, retry if needed
     let mut last_error = String::new();
     let mut success = false;
@@ -92,8 +107,19 @@ pub fn run(args: &AgentRunArgs) -> Result<()> {
         println!("Spawning Claude CLI...");
         let claude_output = match run_claude(&worktree_path, &prompt, args) {
             Ok(output) => {
+                // Record the invocation before quality checks so every attempt
+                // lands a row, even if quality later rejects the result.
+                if let Some(ref c) = conn {
+                    let record = agent_invocation::record_from_subagent(
+                        Caller::AgentRun,
+                        Some("rememora".to_string()),
+                        Some(session_id.clone()),
+                        &output.telemetry,
+                    );
+                    agent_invocation::try_insert(c, &record);
+                }
                 println!("Claude finished. Running quality checks...");
-                output
+                output.text
             }
             Err(e) => {
                 last_error = format!("Claude CLI failed: {e}");
@@ -487,10 +513,12 @@ Fix these issues. Make sure `cargo test` passes and `cargo clippy -- -D warnings
     )
 }
 
-fn run_claude(worktree: &Path, prompt: &str, args: &AgentRunArgs) -> Result<String> {
+fn run_claude(worktree: &Path, prompt: &str, args: &AgentRunArgs) -> Result<SubagentOutput> {
     let mut cmd = Command::new("claude");
     cmd.arg("-p").arg(prompt);
-    cmd.arg("--output-format").arg("text");
+    // `--output-format json` lets us capture usage, cost, duration, and
+    // session id alongside the agent's reply (parsed below).
+    cmd.arg("--output-format").arg("json");
     cmd.current_dir(worktree);
 
     if let Some(ref model) = args.model {
@@ -515,7 +543,9 @@ fn run_claude(worktree: &Path, prompt: &str, args: &AgentRunArgs) -> Result<Stri
         bail!("claude exited with error: {stderr}");
     }
 
-    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let model_hint = args.model.as_deref().unwrap_or("sonnet");
+    parse_subagent_output(&stdout, model_hint)
 }
 
 fn run_quality_checks(worktree: &Path) -> Result<QualityResult> {


### PR DESCRIPTION
## Summary

Wires `agent_run` into the existing `agent_invocations` telemetry that shipped in #69 (migration 004). Every `claude -p` attempt spawned by `rememora agent-run` now records a row with `caller=agent_run`, `parent_session=<rememora session id>`, `project=rememora`, and full subagent telemetry (tokens, cost, duration, child session id, stop/terminal reason).

Closes #70.

## Changes

- `src/commands/agent_run.rs`:
  - Flip `run_claude` from `--output-format text` to `--output-format json` so we can capture usage/cost/duration telemetry.
  - Parse with `curator::parse_subagent_output` — reuses the exact code path the curator already uses; no new parser.
  - Open the default rememora DB at the top of `run()`. If the open fails, emit a one-line warning and skip telemetry rather than blocking the agent run (telemetry is best-effort by design).
  - After each successful `claude -p`, insert a `Caller::AgentRun` row *before* quality checks run, so every attempt is recorded regardless of whether the quality gate later rejects the result.

## Scope

Narrowed from the broader "local-first OTEL" discussion to just the wire-up originally scoped on the issue. A separate follow-up will add a thin OTEL export layer (e.g. `rememora telemetry export-otlp` that reads from `agent_invocations`) rather than duplicating a new spans table alongside the existing telemetry surface. Rationale: `agent_invocations` already captures every field OTEL spans would carry (caller, model, session, tokens, cost, duration); splitting would fork aggregation in `rememora usage`.

## Test plan

- [x] `cargo test --lib` → 45 pass
- [x] `cargo clippy --lib --bins -- -D warnings` → clean
- [ ] Manual: `rememora agent-run --repo X --issue N`, confirm `rememora usage --by caller` shows an `agent_run` row
- [ ] Manual: induce a `claude -p` parse error (malformed JSON) and confirm the agent run still proceeds (no telemetry row, warning logged)

## Notes

- Telemetry is best-effort: `try_insert` already swallows DB errors; the `.ok()` on `db::open` ensures a missing / locked DB doesn't abort the run.
- Pre-existing `-D warnings` clippy failures in `tests/` are unchanged by this PR (untouched files); `cargo clippy --lib --bins` is clean.