### PR TITLE
feat(plugin): REMEMORA_DISABLE_HOOKS=1 kill-switch (#79)

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -29,6 +29,21 @@ claude plugin install rememora@rememora --scope project
 - `rememora` CLI installed and on PATH (`cargo install rememora` or via Homebrew)
 - A registered project: `rememora project add <name> --path <cwd>`
 
+## Escape hatches
+
+If a Rememora hook misbehaves and you need to turn everything off quickly, set the kill-switch in the shell that launches Claude Code:
+
+```bash
+export REMEMORA_DISABLE_HOOKS=1
+```
+
+All three hook scripts (`session-start.sh`, `session-end.sh`, `stop-curate.sh`) check this env var at the top and early-exit 0 when set. `unset REMEMORA_DISABLE_HOOKS` to re-enable.
+
+Other tunables:
+
+- `REMEMORA_CURATE_COOLDOWN_SECS` (default `300`): minimum seconds between curate runs per session. Set to `0` to disable the frequency gate. The kernel-level `pgrep` concurrency gate is independent and always active.
+- `REMEMORA_CURATE_CHILD`: set internally by `rememora curate` on its `claude -p` subprocesses so those children's Stop hooks don't recursively curate. Not intended for user override.
+
 ## How it works
 
 1. On **session start**, the hook runs `rememora context --auto` and injects prior knowledge

--- a/plugin/scripts/session-end.sh
+++ b/plugin/scripts/session-end.sh
@@ -3,6 +3,10 @@
 # Runs once per Claude Code session end; pairs with stop-curate.sh's per-turn cooldown
 # by guaranteeing the tail of the session is captured even if the last Stop hook was
 # inside the cooldown window.
+
+# Kill-switch: set REMEMORA_DISABLE_HOOKS=1 to disable all Rememora hooks.
+[ -n "${REMEMORA_DISABLE_HOOKS:-}" ] && exit 0
+
 set -euo pipefail
 
 if ! command -v rememora &>/dev/null; then

--- a/plugin/scripts/session-start.sh
+++ b/plugin/scripts/session-start.sh
@@ -2,6 +2,9 @@
 # Rememora SessionStart hook — loads project context and starts a session.
 # Runs automatically on every Claude Code session start/resume.
 
+# Kill-switch: set REMEMORA_DISABLE_HOOKS=1 to disable all Rememora hooks.
+[ -n "${REMEMORA_DISABLE_HOOKS:-}" ] && exit 0
+
 set -euo pipefail
 
 # Check if rememora is available

--- a/plugin/scripts/stop-curate.sh
+++ b/plugin/scripts/stop-curate.sh
@@ -5,6 +5,9 @@
 # curates itself.
 [ -n "${REMEMORA_CURATE_CHILD:-}" ] && exit 0
 
+# Kill-switch: set REMEMORA_DISABLE_HOOKS=1 to disable all Rememora hooks.
+[ -n "${REMEMORA_DISABLE_HOOKS:-}" ] && exit 0
+
 # Rememora Stop hook — curates memories from the current session transcript.
 # Runs in the background after each Claude Code agent turn completes.
 # Must never block the agent — all work is forked to a subshell.


### PR DESCRIPTION
## Summary

Adds an env-var escape hatch so users can disable all Rememora hooks in one command without reinstalling the plugin.

Check is placed at the very top of each script — before \`set -euo pipefail\` — so a hook stays silent even if the rest of the script would error. Mirrors the existing \`REMEMORA_CURATE_CHILD\` gate pattern in stop-curate.sh.

Closes #79.

## Changes

- \`plugin/scripts/session-start.sh\`, \`session-end.sh\`, \`stop-curate.sh\`: add \`[ -n \"\${REMEMORA_DISABLE_HOOKS:-}\" ] && exit 0\` at the top
- \`plugin/README.md\`: new \"Escape hatches\" section documenting the new var plus the existing \`REMEMORA_CURATE_COOLDOWN_SECS\` / \`REMEMORA_CURATE_CHILD\`

## Test plan

- [x] \`bash -n\` on all three scripts — syntax ok
- [x] \`REMEMORA_DISABLE_HOOKS=1 bash plugin/scripts/session-start.sh < /dev/null\` → exits 0 silently
- [x] Same for \`session-end.sh\` and \`stop-curate.sh\`
- [ ] Manual: set in live Claude Code session, confirm curate no longer runs

## Risks

None — opt-in, default behavior unchanged.