### PR TITLE
feat(plugin): Setup hook prints actionable install hint (#78)

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -1,5 +1,15 @@
 {
   "hooks": {
+    "Setup": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/setup-check.sh"
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "hooks": [

--- a/plugin/scripts/setup-check.sh
+++ b/plugin/scripts/setup-check.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Rememora Setup hook — one-shot check that the rememora CLI is available.
+#
+# We deliberately DO NOT install anything here. Compare claude-mem's
+# smart-install.js, which installs Bun + Python uv + node deps from a Setup
+# hook and generates a long tail of install-failure reports (#1662, #1503,
+# #1883 in their tracker). Our binary ships via Homebrew; a hook should
+# check-and-inform, never install.
+
+# Kill-switch: set REMEMORA_DISABLE_HOOKS=1 to disable all Rememora hooks.
+[ -n "${REMEMORA_DISABLE_HOOKS:-}" ] && exit 0
+
+if ! command -v rememora >/dev/null 2>&1; then
+  echo "Rememora plugin installed but 'rememora' CLI not found on PATH."
+  echo "Install with: brew install Rememora/tap/rememora  (or: cargo install rememora)"
+fi
+
+# Always succeed — a missing binary is informational, not an error.
+exit 0


### PR DESCRIPTION
## Summary

Add a \`Setup\` hook that prints a one-line install hint when the \`rememora\` CLI is not on PATH. Never installs anything — check-and-inform only.

Closes #78.

## Why

Today, installing the plugin without the CLI on PATH yields silent no-ops in every hook (\`command -v rememora &>/dev/null || exit 0\` at the top of each script). Users get zero signal that memory isn't loading.

A one-line hint unblocks them:

\`\`\`
Rememora plugin installed but 'rememora' CLI not found on PATH.
Install with: brew install Rememora/tap/rememora  (or: cargo install rememora)
\`\`\`

## Explicitly NOT doing

- Auto-installing anything from the hook — claude-mem's \`smart-install.js\` runs Bun + Python uv + node installers and generates a long tail of failure reports (#1662, #1503, #1883 in their tracker). We ship a single binary via Homebrew; a hook should check-and-inform, never install.
- Detecting stale versions / broken configs — out of scope for this ticket.

## Changes

- New \`plugin/scripts/setup-check.sh\` (chmod +x, also honors \`REMEMORA_DISABLE_HOOKS=1\`)
- \`plugin/hooks/hooks.json\`: register \`Setup\` entry at the top

## Test plan

- [x] JSON validates (\`python3 -m json.tool\`)
- [x] \`bash -n\` on script
- [x] Script with rememora on PATH → exits 0 silently
- [x] Script with PATH stripped → prints hint, exits 0
- [ ] Manual: install plugin in a fresh environment without rememora, confirm hint appears