### PR TITLE
feat(plugin): hook P0 polish — stop-hook JSON, session-end detach, SessionStart matchers (#74)

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -2,6 +2,7 @@
   "hooks": {
     "SessionStart": [
       {
+        "matcher": "startup|clear|compact|resume",
         "hooks": [
           {
             "type": "command",

--- a/plugin/scripts/session-end.sh
+++ b/plugin/scripts/session-end.sh
@@ -21,9 +21,22 @@ if [ -n "$CWD" ] && [ -n "$SESSION_ID" ]; then
   PROJECT=$(basename "$CWD")
 
   if [ -f "$JSONL_PATH" ]; then
-    (
-      rememora curate --file "$JSONL_PATH" --project "$PROJECT" 2>/dev/null || true
-    ) &
+    # Fully detach the final-pass curate. Plain `&` backgrounds scheduling
+    # but does NOT close inherited file descriptors — a curate subprocess
+    # that lingers past SessionEnd could keep the hook's pipe write-end
+    # open and cause the same FD-leak blocking we fixed in stop-curate.sh.
+    # Apply the same setsid (Linux) / nohup + disown (macOS) detachment and
+    # redirect all three std streams on the outer launch.
+    if command -v setsid >/dev/null 2>&1; then
+      setsid bash -c '
+        rememora curate --file "$1" --project "$2" >/dev/null 2>&1 || true
+      ' _ "$JSONL_PATH" "$PROJECT" </dev/null >/dev/null 2>&1 &
+    else
+      nohup bash -c '
+        rememora curate --file "$1" --project "$2" >/dev/null 2>&1 || true
+      ' _ "$JSONL_PATH" "$PROJECT" </dev/null >/dev/null 2>&1 &
+      disown
+    fi
   fi
 
   LOCK_DIR="${TMPDIR:-/tmp}"

--- a/plugin/scripts/session-start.sh
+++ b/plugin/scripts/session-start.sh
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash
 # Rememora SessionStart hook — loads project context and starts a session.
-# Runs automatically on every Claude Code session start/resume.
+# Runs on every Claude Code session start / clear / compact / resume.
+#
+# Claude Code passes a `source` field on stdin JSON indicating which variant
+# triggered the hook. We branch on it:
+#   startup (default) → inject full context, start a new session row
+#   resume            → skip `session start` (existing row continues); still inject context
+#   clear             → user asked for a clean slate: skip context injection entirely
+#   compact           → inject a compact cheatsheet rather than full L0/L1 to
+#                       avoid token pressure right after compaction (falls back
+#                       to full context if --cheatsheet is unavailable)
+#
+# When `source` is missing (older Claude Code versions) we default to the
+# startup path — current behavior is preserved.
 
 set -euo pipefail
 
@@ -9,24 +21,40 @@ if ! command -v rememora &>/dev/null; then
   exit 0
 fi
 
-# Load project context (auto-detects from CWD)
-CONTEXT=$(rememora context --auto 2>/dev/null || true)
-
-if [ -n "$CONTEXT" ]; then
-  # Output goes to Claude as additionalContext
-  echo "$CONTEXT"
-  echo ""
-  echo "---"
-  echo "The above is your project memory from rememora. Use it to inform your work."
-  echo "Remember to save new decisions, bug fixes, and patterns as you work."
+# Capture stdin (may be empty on older Claude Code versions).
+INPUT=$(cat 2>/dev/null || true)
+SOURCE=""
+if [ -n "$INPUT" ]; then
+  SOURCE=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('source',''))" 2>/dev/null || echo "")
 fi
 
-# Start a session (captures session ID for later)
-rememora session start --agent claude-code --project "$(basename "$PWD")" --intent "Interactive session" 2>/dev/null || true
-
-# Check if consolidation is due (dual gate: 24h + 5 new memories)
-# Exit code 42 means gate is met — run consolidation in background
 PROJECT=$(basename "$PWD")
+
+# Context injection — skip entirely on `clear` (user wants a clean slate).
+if [ "$SOURCE" != "clear" ]; then
+  if [ "$SOURCE" = "compact" ]; then
+    CONTEXT=$(rememora context --auto --cheatsheet 2>/dev/null || rememora context --auto 2>/dev/null || true)
+  else
+    CONTEXT=$(rememora context --auto 2>/dev/null || true)
+  fi
+
+  if [ -n "${CONTEXT:-}" ]; then
+    echo "$CONTEXT"
+    echo ""
+    echo "---"
+    echo "The above is your project memory from rememora. Use it to inform your work."
+    echo "Remember to save new decisions, bug fixes, and patterns as you work."
+  fi
+fi
+
+# Session row — only create a new one on genuine startup. Resuming continues
+# the existing row; clear/compact stay within the current session.
+if [ -z "$SOURCE" ] || [ "$SOURCE" = "startup" ]; then
+  rememora session start --agent claude-code --project "$PROJECT" --intent "Interactive session" 2>/dev/null || true
+fi
+
+# Consolidation gate runs on every source — cheap (exit-code only) and worth
+# catching on resume/compact too.
 rememora consolidate --check-only --project "$PROJECT" 2>/dev/null
 if [ $? -eq 42 ]; then
   (rememora consolidate --project "$PROJECT" 2>/dev/null || true) &

--- a/plugin/scripts/stop-curate.sh
+++ b/plugin/scripts/stop-curate.sh
@@ -92,4 +92,9 @@ else
   disown
 fi
 
+# Suppress the "running Stop hook..." footer in Claude Code. suppressOutput
+# is required — `{"continue":true}` alone has been observed to cause an
+# infinite Stop-hook loop in other plugins (claude-mem #1288).
+echo '{"continue":true,"suppressOutput":true}'
+
 exit 0


### PR DESCRIPTION
## Summary

Three small hook improvements derived from a deep comparison against thedotmack/claude-mem. All three are preventive or UX fixes grounded in their production incidents.

Closes #74.

## 1. stop-curate.sh emits suppressive JSON

Add \`echo '{\"continue\":true,\"suppressOutput\":true}'\` after the detached curate launch. Suppresses the \"running Stop hook...\" footer that currently flickers even though the curate has already detached.

**Critical**: \`suppressOutput\` is required — \`{\"continue\":true}\` alone caused an infinite Stop-hook loop in claude-mem (#1288). That bug is cited in the code comment.

## 2. session-end.sh applies setsid/nohup detachment

Previously used plain \`&\` — same FD-leak class as the 10–97 min Claude Code hangs documented in the \`case_stop_hook_fd_leak_blocking\` memory. Applies the exact pattern already in stop-curate.sh: \`setsid\` (Linux) or \`nohup + disown\` (macOS), with \`</dev/null >/dev/null 2>&1 &\` on the outer launch. Preventive only — no known incident yet.

## 3. SessionStart matches \`startup|clear|compact|resume\`

Add matcher and branch on the \`source\` field in stdin JSON:

| source | session row | context injection |
|---|---|---|
| \`startup\` (default) | new row | full L0/L1 |
| \`resume\` | continue existing | full L0/L1 |
| \`clear\` | continue | **skipped** (user wanted clean slate) |
| \`compact\` | continue | \`--cheatsheet\` (falls back to full) |

Missing \`source\` (older Claude Code versions) falls through to the startup path — current behavior is preserved.

## Test plan

- [x] \`python3 -m json.tool plugin/hooks/hooks.json\` validates
- [x] \`bash -n\` on all three scripts
- [x] \`echo '{\"source\":\"clear\", ...}' | bash session-start.sh\` → skips context injection, runs consolidation gate only
- [x] \`echo '{\"source\":\"resume\", ...}' | bash session-start.sh\` → injects context, skips \`rememora session start\`
- [x] \`echo '{}' | bash session-start.sh\` → default startup path (backward compatible)
- [x] \`REMEMORA_CURATE_CHILD=1 bash stop-curate.sh\` → still exits 0 (recursion gate unchanged)
- [ ] Manual: run in live Claude Code session, confirm footer disappears

## Anti-patterns this PR explicitly does NOT introduce

- No \`PostToolUse\` handler
- No localhost port binding
- No persistent worker process
- No PATH-recovery prelude
- No auto-install

## Open question (resolved by runtime fallback)

Whether Claude Code actually emits a \`source\` field in SessionStart JSON — older versions may not. The script handles both cases: if \`source\` is missing or empty, falls back to startup behavior.