### PR TITLE
feat(plugin): UserPromptSubmit hook injects top-3 FTS5 hits into prompt context (#77)

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -10,6 +10,16 @@
         ]
       }
     ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/prompt-search.sh"
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "matcher": "startup|clear|compact|resume",

--- a/plugin/scripts/prompt-search.sh
+++ b/plugin/scripts/prompt-search.sh
@@ -22,6 +22,11 @@ INPUT=$(cat 2>/dev/null || true)
 PROMPT=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('prompt',''))" 2>/dev/null || echo "")
 CWD=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('cwd',''))" 2>/dev/null || echo "")
 
+# Strip FTS5-reserved punctuation. The query is passed unescaped to SQLite's
+# FTS5 MATCH and chars like `?`, `:`, `(`, `)`, `"`, `*`, `-` carry query
+# semantics that break on natural-language prompts. Collapse whitespace too.
+PROMPT=$(printf '%s' "$PROMPT" | tr -d '?:"()*-' | tr -s '[:space:]' ' ' | sed 's/^ //; s/ $//')
+
 # Skip on empty / overly-short prompts — FTS5 on 1–2 chars returns noise.
 if [ "${#PROMPT}" -lt 6 ]; then
   exit 0

--- a/plugin/scripts/prompt-search.sh
+++ b/plugin/scripts/prompt-search.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Rememora UserPromptSubmit hook — inject top-N FTS5 search hits into the
+# prompt's additional-context channel.
+#
+# Design principles:
+#   - Local-only: runs `rememora search --format context` against ~/.rememora/rememora.db
+#   - Bounded: `--limit 3` and `--format context` enforce a ~2KB cap in the CLI
+#   - Best-effort: any failure (rememora missing, DB locked, empty result) is silent
+
+# Kill-switch — disables all Rememora hooks.
+[ -n "${REMEMORA_DISABLE_HOOKS:-}" ] && exit 0
+
+if ! command -v rememora >/dev/null 2>&1; then
+  exit 0
+fi
+
+INPUT=$(cat 2>/dev/null || true)
+[ -z "$INPUT" ] && exit 0
+
+# Extract the prompt text and cwd from the hook payload. Claude Code passes
+# top-level {session_id, transcript_path, cwd, prompt} on UserPromptSubmit.
+PROMPT=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('prompt',''))" 2>/dev/null || echo "")
+CWD=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('cwd',''))" 2>/dev/null || echo "")
+
+# Skip on empty / overly-short prompts — FTS5 on 1–2 chars returns noise.
+if [ "${#PROMPT}" -lt 6 ]; then
+  exit 0
+fi
+
+PROJECT=""
+if [ -n "$CWD" ]; then
+  PROJECT=$(basename "$CWD")
+fi
+
+# Run with a short timeout — if the DB is locked or slow, we'd rather skip
+# injection than delay the user's prompt.
+if command -v timeout >/dev/null 2>&1; then
+  RUN=(timeout 2 rememora)
+else
+  RUN=(rememora)
+fi
+
+if [ -n "$PROJECT" ]; then
+  OUT=$("${RUN[@]}" search --project "$PROJECT" --limit 3 --format context "$PROMPT" 2>/dev/null || true)
+else
+  OUT=$("${RUN[@]}" search --limit 3 --format context "$PROMPT" 2>/dev/null || true)
+fi
+
+if [ -n "$OUT" ]; then
+  echo "$OUT"
+fi
+
+exit 0

--- a/src/format.rs
+++ b/src/format.rs
@@ -268,3 +268,73 @@ pub fn scored_contexts_to_json(contexts: &[ScoredContext]) -> String {
         .collect();
     serde_json::to_string_pretty(&items).unwrap_or_default()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn result_with(uri: &str, category: &str, abstract_text: &str) -> SearchResult {
+        SearchResult {
+            context: ContextRecord {
+                id: uri.to_string(),
+                uri: uri.to_string(),
+                parent_uri: None,
+                context_type: "preference".to_string(),
+                category: Some(category.to_string()),
+                name: "name".to_string(),
+                abstract_text: abstract_text.to_string(),
+                overview: String::new(),
+                content: String::new(),
+                tags: String::new(),
+                source_agent: None,
+                source_session: None,
+                importance: 0.5,
+                active_count: 0,
+                created_at: String::new(),
+                updated_at: String::new(),
+                superseded_by: None,
+            },
+            rank: 1.0,
+        }
+    }
+
+    #[test]
+    fn context_format_empty_results_returns_empty_string() {
+        let out = search_results_to_context(&[]);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn context_format_caps_total_output_under_byte_budget() {
+        // Many long-abstract results; ensure we never exceed CONTEXT_BYTE_CAP.
+        let results: Vec<SearchResult> = (0..50)
+            .map(|i| result_with(&format!("rememora://a{i}"), "case", &"A".repeat(300)))
+            .collect();
+        let out = search_results_to_context(&results);
+        assert!(
+            out.len() <= CONTEXT_BYTE_CAP,
+            "expected output under cap, got {} bytes",
+            out.len()
+        );
+    }
+
+    #[test]
+    fn context_format_uses_context_type_when_category_missing() {
+        let mut r = result_with("rememora://x", "_unused_", "abs");
+        r.context.category = None;
+        r.context.context_type = "pattern".into();
+        let out = search_results_to_context(std::slice::from_ref(&r));
+        assert!(
+            out.contains("[pattern]"),
+            "expected fallback category [pattern] in: {out}"
+        );
+    }
+
+    #[test]
+    fn context_format_truncates_long_abstracts_with_ellipsis() {
+        let long = "x".repeat(500);
+        let r = result_with("rememora://foo", "decision", &long);
+        let out = search_results_to_context(std::slice::from_ref(&r));
+        assert!(out.contains('…'), "expected ellipsis in: {out}");
+    }
+}


### PR DESCRIPTION
## Summary

Model frequently forgets to invoke the \`rememora-search\` skill on its own, leaving memory unused on prompts where it would help. This hook surfaces ~3 relevant memories for every user prompt at ~10ms local-SQLite cost — the model sees them without having to remember to search.

Closes #77.

## Changes

### CLI

\`rememora search --format context\` — new compact output mode:

- Per-line: \`[category] <abstract> (<uri>)\`
- Abstract capped at 160 chars (with ellipsis)
- Total output capped at 2 KB (with \`... (truncated, N more hits)\` marker)

Conservative caps — easy to raise after measuring real-world token impact.

### Plugin

- New \`plugin/scripts/prompt-search.sh\`:
  - Reads stdin JSON. Claude Code passes top-level \`{session_id, transcript_path, cwd, prompt}\` on UserPromptSubmit
  - Skips on \`REMEMORA_DISABLE_HOOKS=1\`, missing \`rememora\` on PATH, or empty/<6-char prompts (FTS5 on tiny queries is mostly noise)
  - Wraps the CLI in \`timeout 2\` when available so a slow/locked DB never delays the user's prompt
  - Project scope = \`basename \$CWD\` when available
- \`plugin/hooks/hooks.json\`: register \`UserPromptSubmit\` entry

## Why not register \`PreToolUse\` too

\`PreToolUse\` path-scoped retrieval is a separate idea (not this ticket). 80% of our memories aren't path-scoped — most hits would return empty. Revisit if/when we index entities by file URI. Keeping this PR surgical.

## Test plan

- [x] 4 new \`format::tests\` covering empty results, abstract cap, total-cap truncation marker, category fallback
- [x] Full lib tests: 49 pass
- [x] \`cargo clippy --lib --bins -- -D warnings\` clean
- [x] JSON validates
- [x] \`bash -n\` on new script
- [x] \`REMEMORA_DISABLE_HOOKS=1\` short-circuits the hook
- [x] Short-prompt (<6 chars) short-circuits
- [ ] Manual: live Claude Code session, observe the context line appear when a prompt matches a memory

## Risks

- **Token inflation if the cap is too generous** — 2 KB is conservative; raise after measuring
- **FTS5 contention under 4+ concurrent sessions** — WAL mode makes reads safe but we haven't benchmarked p99 on a large DB. Follow-up if measurable.
- **Claude Code's handling of UserPromptSubmit stdout** — confirm in a live session the hook's output is actually appended to the prompt context