### PR TITLE
feat(search): progressive-disclosure CLI (#80)

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,8 @@ cargo tauri dev
 | Command | Description |
 |---------|-------------|
 | `rememora save "..." --category <cat>` | Save a memory |
-| `rememora search "query"` | Search memories (BM25 + optional vector) |
+| `rememora search "query" [--format compact\|context\|full]` | Search memories (BM25 + optional vector) |
+| `rememora timeline --anchor <uri> [--before N] [--after N]` | Chronological (or hotness-ranked) slice around an anchor |
 | `rememora context --project <name>` | Load full project context (L0 + L1) |
 | `rememora context --auto` | Auto-detect project from cwd |
 | `rememora context --cheatsheet` | Compact top-5 summary |
@@ -284,6 +285,44 @@ cargo tauri dev
 | `rememora export --project <name>` | Export as JSON or markdown |
 
 All commands support `--json` for structured output.
+
+## Progressive Disclosure: search → timeline → get
+
+Retrieving a single memory at full fidelity eats tokens fast. Rememora splits retrieval into three cheap steps so agents can filter before paying the full cost:
+
+```bash
+# 1. Filter — one line per hit, ~75 tokens each
+rememora search "auth flow" --project myapp --format compact
+# [case] Bug fixed: token refresh race … — rememora://…/bug-fixed-token-refresh-race (rank=-3.82)
+# [decision] Chose JWT over session cookies … — rememora://…/chose-jwt-over-session-cookies  (rank=-3.41)
+# [pattern] Auth middleware composition … — rememora://…/auth-middleware-composition       (rank=-3.05)
+
+# 2. Zoom — chronological slice around an anchor to understand what surrounded the decision
+rememora timeline --anchor "rememora://projects/myapp/memories/decision/chose-jwt-over-session-cookies" \
+    --before 3 --after 3
+# Before
+# - [case] Investigated session-cookie CSRF hardening … — 2026-03-14T…
+# - [event] Benchmarked JWT verify latency in middleware … — 2026-03-15T…
+# - [pattern] Double-submit cookie pattern for CSRF … — 2026-03-15T…
+# Anchor
+# - [decision] Chose JWT over session cookies … — 2026-03-16T…
+# After
+# - [case] Refresh-token rotation leak caught in review — 2026-03-18T…
+# …
+
+# 3. Fetch — full content (L2) of a single URI when you're sure you want it
+rememora get "rememora://projects/myapp/memories/decision/chose-jwt-over-session-cookies"
+```
+
+Output formats for `search`:
+
+| `--format` | Shape | Typical use |
+|---|---|---|
+| `full` (default) | Multi-line per hit with name + URI | Human in terminal |
+| `compact` | One line per hit with score, ~75 tok/hit | Agent filtering |
+| `context` | One line per hit, byte-capped (2 KB) | `UserPromptSubmit` hook injection |
+
+Timeline ordering: `--by ts` (default, creation time) or `--by hotness` (importance × recency × active_count). Project scope: explicit `--project` wins; otherwise inferred from the anchor URI.
 
 ## Auto-Extract Memories
 

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -65,6 +65,7 @@
         <ul class="docs-sidebar-links">
           <li><a href="#cmd-save">save</a></li>
           <li><a href="#cmd-search">search</a></li>
+          <li><a href="#cmd-timeline">timeline</a></li>
           <li><a href="#cmd-context">context</a></li>
           <li><a href="#cmd-session">session</a></li>
           <li><a href="#cmd-project">project</a></li>
@@ -417,7 +418,7 @@ Before ending: `rememora session end &lt;id&gt; --summary "..." ...`
       </table>
 
       <h2 id="cmd-search">search</h2>
-      <p>Search memories using BM25 full-text search (or hybrid with vector if enabled).</p>
+      <p>Search memories using BM25 full-text search (or hybrid with vector if enabled). <code>--format</code> controls the output shape — pick <code>compact</code> when an agent is filtering before zooming in with <code>timeline</code> / <code>get</code>.</p>
       <div class="code-window">
         <div class="code-header">
           <div class="code-dots"><span class="red"></span><span class="yellow"></span><span class="green"></span></div>
@@ -429,9 +430,87 @@ Before ending: `rememora session end &lt;id&gt; --summary "..." ...`
     <span class="flag">--project</span> &lt;name&gt; \
     <span class="flag">--category</span> &lt;category&gt; \
     <span class="flag">--limit</span> &lt;n&gt; \
+    <span class="flag">--format</span> &lt;full|compact|context&gt; \
     <span class="flag">--json</span></pre>
         </div>
       </div>
+      <table>
+        <thead><tr><th><code>--format</code></th><th>Shape</th><th>Typical use</th></tr></thead>
+        <tbody>
+          <tr><td><code>full</code> (default)</td><td>Multi-line per hit with name, URI, metadata</td><td>Human in terminal</td></tr>
+          <tr><td><code>compact</code></td><td>One line per hit with score, ~75 tok/hit</td><td>Agent filtering before a <code>timeline</code> / <code>get</code></td></tr>
+          <tr><td><code>context</code></td><td>One line per hit, byte-capped (2 KB)</td><td><code>UserPromptSubmit</code> hook injection</td></tr>
+        </tbody>
+      </table>
+      <div class="code-window">
+        <div class="code-header">
+          <div class="code-dots"><span class="red"></span><span class="yellow"></span><span class="green"></span></div>
+          <span class="code-title">example — compact filter view</span>
+          <span></span>
+        </div>
+        <div class="code-body">
+<pre><span class="prompt">$</span> <span class="cmd">rememora</span> <span class="cmd">search</span> <span class="string">"auth flow"</span> <span class="flag">--project</span> myapp <span class="flag">--format</span> compact
+[case] Bug fixed: token refresh race … — rememora://…/bug-fixed-token-refresh-race (rank=-3.82)
+[decision] Chose JWT over session cookies … — rememora://…/chose-jwt-over-session-cookies  (rank=-3.41)
+[pattern] Auth middleware composition … — rememora://…/auth-middleware-composition       (rank=-3.05)</pre>
+        </div>
+      </div>
+
+      <h2 id="cmd-timeline">timeline</h2>
+      <p>Chronological (or hotness-ranked) slice around an anchor URI. The middle step in the progressive-disclosure flow: <code>search</code> (filter) → <code>timeline</code> (zoom) → <code>get</code> (full content). Lets an agent see what memories surrounded a decision without pulling full content for every hit.</p>
+      <div class="code-window">
+        <div class="code-header">
+          <div class="code-dots"><span class="red"></span><span class="yellow"></span><span class="green"></span></div>
+          <span class="code-title">usage</span>
+          <button class="code-copy">Copy</button>
+        </div>
+        <div class="code-body">
+<pre><span class="cmd">rememora</span> <span class="cmd">timeline</span> <span class="flag">--anchor</span> &lt;rememora://...&gt; \
+    <span class="flag">--before</span> &lt;n&gt; \
+    <span class="flag">--after</span> &lt;n&gt; \
+    <span class="flag">--project</span> &lt;name&gt; \
+    <span class="flag">--by</span> &lt;ts|hotness&gt; \
+    <span class="flag">--json</span></pre>
+        </div>
+      </div>
+      <table>
+        <thead><tr><th>Flag</th><th>Default</th><th>Description</th></tr></thead>
+        <tbody>
+          <tr><td><code>--anchor</code></td><td>required</td><td>The rememora:// URI to center the slice on</td></tr>
+          <tr><td><code>--before</code></td><td><code>3</code></td><td>Number of memories before the anchor</td></tr>
+          <tr><td><code>--after</code></td><td><code>3</code></td><td>Number of memories after the anchor</td></tr>
+          <tr><td><code>--project</code></td><td>inferred</td><td>Scope. Inferred from the anchor URI if omitted</td></tr>
+          <tr><td><code>--by</code></td><td><code>ts</code></td><td>Ordering — <code>ts</code> (creation time) or <code>hotness</code> (importance blended with recency + access count)</td></tr>
+        </tbody>
+      </table>
+      <div class="code-window">
+        <div class="code-header">
+          <div class="code-dots"><span class="red"></span><span class="yellow"></span><span class="green"></span></div>
+          <span class="code-title">example — zoom around a decision</span>
+          <span></span>
+        </div>
+        <div class="code-body">
+<pre><span class="prompt">$</span> <span class="cmd">rememora</span> <span class="cmd">timeline</span> \
+    <span class="flag">--anchor</span> <span class="string">"rememora://projects/myapp/memories/decision/chose-jwt-over-session-cookies"</span> \
+    <span class="flag">--before</span> 3 <span class="flag">--after</span> 3
+
+<span class="comment"># Timeline around `rememora://.../chose-jwt-over-session-cookies`</span>
+
+## Before
+- [case] Investigated session-cookie CSRF hardening … — 2026-03-14T…
+- [event] Benchmarked JWT verify latency in middleware … — 2026-03-15T…
+- [pattern] Double-submit cookie pattern for CSRF … — 2026-03-15T…
+
+## Anchor
+**- [decision] Chose JWT over session cookies … — 2026-03-16T…**
+
+## After
+- [case] Refresh-token rotation leak caught in review — 2026-03-18T…
+- [case] Bug fixed: token refresh race … — 2026-03-19T…
+- [pattern] Auth middleware composition … — 2026-03-20T…</pre>
+        </div>
+      </div>
+      <p><strong>Progressive disclosure.</strong> A typical agent retrieval now costs ~75 tokens per filter hit, ~200 tokens for a slice of surrounding context, and only pays full content cost when it calls <code>rememora get &lt;uri&gt;</code> on the one memory it actually needs. Compare: pre-PR #80, every <code>search</code> hit pulled the full overview block.</p>
 
       <h2 id="cmd-context">context</h2>
       <p>Load full project context — memories, last session, working state. The primary entry point for agents at session start.</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -518,7 +518,7 @@
           </div>
           <div class="arch-layer">
             <div class="arch-layer-title">Layer 1: CLI Core</div>
-            <div class="arch-layer-desc">save, search, context, session, curate, evolve, extract, project, export, tui &bull; SQLite + FTS5 + WAL &bull; SQLCipher encryption</div>
+            <div class="arch-layer-desc">save, search, timeline, context, session, curate, evolve, extract, project, export, tui &bull; SQLite + FTS5 + WAL &bull; SQLCipher encryption</div>
           </div>
         </div>
       </div>

--- a/plugin/skills/rememora-search/SKILL.md
+++ b/plugin/skills/rememora-search/SKILL.md
@@ -13,20 +13,74 @@ allowed-tools: Bash
 
 # Search Rememora for Prior Knowledge
 
-Before starting this work, check if there's relevant knowledge from prior sessions.
+Before starting non-trivial work, check if there is relevant knowledge from
+prior sessions. Rememora stores memories in three tiers (L0 abstract, L1
+overview, L2 content), so you can filter cheaply before paying the full
+token cost of a memory.
 
-## How to search
+## Progressive-disclosure workflow (search → timeline → get)
 
-Run this command via Bash:
+Do not pull full memory content up front. Use the three verbs in order.
+
+### 1. `rememora search --format compact` — filter
+
+Scan for relevant memories by topic. Compact output is one line per hit
+(~75 tokens/hit), enough to decide whether to drill in.
 
 ```bash
-rememora search "<what you're looking for>" --project <project-name>
+rememora search "<what you're looking for>" --project <project-name> --format compact
 ```
 
-### Search query tips
-- Use the topic or domain: `"database choice"`, `"auth middleware"`, `"payment processing"`
-- Use the problem area: `"JWT token expiration"`, `"rate limiting"`, `"test flakiness"`
-- Use the entity name: `"Stripe integration"`, `"user service"`, `"prisma schema"`
+Each line looks like:
+
+```
+[decision] Picked Redis over Memcached — rememora://projects/foo/memories/decision/redis-caching (rank=-1.23)
+```
+
+Query tips:
+- Use the topic or domain: `"database choice"`, `"auth middleware"`
+- Use the problem area: `"JWT token expiration"`, `"rate limiting"`
+- Use the entity name: `"Stripe integration"`, `"prisma schema"`
+
+### 2. `rememora timeline --anchor <uri>` — context around a hit
+
+Once a hit looks promising, pull the neighbours around it to understand
+what else was happening when that decision was made. Sorted by creation
+time by default (`--by ts`); use `--by hotness` to rank peers by
+importance + hotness instead.
+
+```bash
+rememora timeline \
+  --anchor rememora://projects/foo/memories/decision/redis-caching \
+  --before 3 --after 3
+```
+
+You get the three closest older memories, the anchor, and the three
+closest newer memories — each rendered in the same compact shape.
+
+### 3. `rememora get <uri>` — full L2 content
+
+Only when you know you want everything: pull the full abstract + overview +
+content for a specific URI.
+
+```bash
+rememora get rememora://projects/foo/memories/decision/redis-caching
+```
+
+## Example flow
+
+```bash
+# Step 1: filter
+rememora search "caching strategy" --project acme --format compact
+# → hit: rememora://projects/acme/memories/decision/redis-caching (rank=-2.1)
+
+# Step 2: context
+rememora timeline --anchor rememora://projects/acme/memories/decision/redis-caching --before 3 --after 3
+# → see what else was decided that week
+
+# Step 3: full content (only for the most relevant hit)
+rememora get rememora://projects/acme/memories/decision/redis-caching
+```
 
 ## When to search
 
@@ -46,6 +100,7 @@ rememora search "<what you're looking for>" --project <project-name>
 
 ## Rules
 
-1. **Search BEFORE acting** — don't implement first and search after
-2. **Be brief** — one search, check results, move on
-3. **Don't search for things you can just read** — use Read/Grep for code, rememora for decisions and context
+1. **Search BEFORE acting** — don't implement first and search after.
+2. **Filter cheaply first** — `--format compact` for search, then `timeline`, then `get`. Do not default to the full `search` output — it burns tokens.
+3. **Be brief** — one search, check results, move on.
+4. **Don't search for things you can just read** — use Read/Grep for code, rememora for decisions and context.

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -18,5 +18,6 @@ pub mod session;
 pub mod setup;
 pub mod status;
 pub mod supersede;
+pub mod timeline;
 pub mod tui;
 pub mod usage;

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -1,9 +1,32 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
 use rusqlite::Connection;
 
 use rememora::format;
 use rememora::propagate::PropagationConfig;
 use rememora::search;
+
+/// Output mode for `rememora search`.
+///
+/// - `Full`: current markdown format (numbered list, multi-line per hit).
+/// - `Compact`: progressive-disclosure single-line-per-hit (~75 tokens).
+/// - `Context`: tiny, length-capped form safe for inline prompt injection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SearchFormat {
+    Full,
+    Compact,
+    Context,
+}
+
+impl SearchFormat {
+    pub fn parse(s: &str) -> Result<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "full" | "markdown" | "md" => Ok(Self::Full),
+            "compact" => Ok(Self::Compact),
+            "context" => Ok(Self::Context),
+            other => bail!("unknown --format value: {other} (expected full|compact|context)"),
+        }
+    }
+}
 
 pub struct SearchArgs {
     pub query: String,
@@ -13,6 +36,7 @@ pub struct SearchArgs {
     pub propagate: bool,
     pub propagate_decay: f64,
     pub propagate_depth: usize,
+    pub format: SearchFormat,
 }
 
 pub fn run(conn: &Connection, args: &SearchArgs, json: bool) -> Result<()> {
@@ -42,7 +66,11 @@ pub fn run(conn: &Connection, args: &SearchArgs, json: bool) -> Result<()> {
     if json {
         println!("{}", format::search_results_to_json(&results));
     } else {
-        print!("{}", format::search_results_to_markdown(&results));
+        match args.format {
+            SearchFormat::Full => print!("{}", format::search_results_to_markdown(&results)),
+            SearchFormat::Compact => print!("{}", format::search_results_to_compact(&results)),
+            SearchFormat::Context => print!("{}", format::search_results_to_context(&results)),
+        }
     }
 
     Ok(())

--- a/src/commands/timeline.rs
+++ b/src/commands/timeline.rs
@@ -1,0 +1,94 @@
+//! `rememora timeline` — chronological slice of contexts around an anchor URI.
+//!
+//! Thin CLI wrapper over [`rememora::timeline::build_timeline`]. Library-side
+//! logic lives in `src/timeline.rs` so behavior tests can exercise it without
+//! pulling the binary crate.
+
+use anyhow::Result;
+use rusqlite::Connection;
+
+use rememora::models::context::{self, ContextRecord};
+use rememora::timeline::{self, Timeline};
+
+// Re-export so `main.rs` can stay on the `commands::timeline::*` path.
+pub use rememora::timeline::{TimelineArgs, TimelineOrder};
+
+pub fn run(conn: &Connection, args: &TimelineArgs, json: bool) -> Result<()> {
+    let t = timeline::build_timeline(conn, args)?;
+
+    // Match the `get` command's side effect: accessing the anchor bumps its
+    // active_count, which feeds hotness on future searches.
+    context::bump_active_count(conn, &t.anchor.id)?;
+
+    if json {
+        println!("{}", to_json(&t));
+    } else {
+        print!("{}", to_markdown(&t));
+    }
+
+    Ok(())
+}
+
+fn compact_line(ctx: &ContextRecord) -> String {
+    let cat = ctx.category.as_deref().unwrap_or(&ctx.context_type);
+    let abstract_text = if !ctx.abstract_text.is_empty() {
+        ctx.abstract_text.as_str()
+    } else {
+        ctx.name.as_str()
+    };
+    format!(
+        "- [{}] {} — `{}` ({})",
+        cat, abstract_text, ctx.uri, ctx.created_at
+    )
+}
+
+fn to_markdown(t: &Timeline) -> String {
+    let mut md = String::new();
+    md.push_str(&format!("# Timeline around `{}`\n\n", t.anchor.uri));
+
+    if !t.before.is_empty() {
+        md.push_str("## Before\n\n");
+        for ctx in &t.before {
+            md.push_str(&compact_line(ctx));
+            md.push('\n');
+        }
+        md.push('\n');
+    }
+
+    md.push_str("## Anchor\n\n");
+    md.push_str(&format!("**{}**\n", compact_line(&t.anchor)));
+    md.push('\n');
+
+    if !t.after.is_empty() {
+        md.push_str("## After\n\n");
+        for ctx in &t.after {
+            md.push_str(&compact_line(ctx));
+            md.push('\n');
+        }
+        md.push('\n');
+    }
+
+    md
+}
+
+fn to_json(t: &Timeline) -> String {
+    let render = |c: &ContextRecord| {
+        serde_json::json!({
+            "id": c.id,
+            "uri": c.uri,
+            "name": c.name,
+            "category": c.category,
+            "abstract": c.abstract_text,
+            "importance": c.importance,
+            "created_at": c.created_at,
+            "active_count": c.active_count,
+        })
+    };
+
+    let payload = serde_json::json!({
+        "anchor": render(&t.anchor),
+        "before": t.before.iter().map(render).collect::<Vec<_>>(),
+        "after": t.after.iter().map(render).collect::<Vec<_>>(),
+    });
+    serde_json::to_string_pretty(&payload).unwrap_or_default()
+}

--- a/src/format.rs
+++ b/src/format.rs
@@ -92,6 +92,88 @@ pub fn search_results_to_markdown(results: &[SearchResult]) -> String {
     md
 }
 
+/// Target line length for compact search output (~75 tokens).
+const COMPACT_LINE_LEN: usize = 140;
+/// Overall byte cap for context-mode search output (prompt injection safety).
+const CONTEXT_BYTE_CAP: usize = 1200;
+/// Per-line abstract length for context-mode.
+const CONTEXT_LINE_LEN: usize = 100;
+
+fn truncate_ellipsis(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let mut out: String = s.chars().take(max.saturating_sub(1)).collect();
+    out.push('…');
+    out
+}
+
+fn pick_abstract(ctx: &crate::models::context::ContextRecord) -> &str {
+    if !ctx.abstract_text.is_empty() {
+        &ctx.abstract_text
+    } else {
+        &ctx.name
+    }
+}
+
+/// Compact progressive-disclosure output: one line per hit, ~75 tokens each.
+///
+/// Shape: `[category] abstract — rememora://... (rank=-1.23)`
+///
+/// Designed for agents to filter before fetching: enough signal to decide
+/// whether to drill into `timeline` or `get`, without spending the token
+/// budget that the default markdown format would.
+pub fn search_results_to_compact(results: &[SearchResult]) -> String {
+    if results.is_empty() {
+        return "No results found.\n".to_string();
+    }
+
+    let mut out = String::new();
+    for result in results {
+        let ctx = &result.context;
+        let cat = ctx.category.as_deref().unwrap_or(&ctx.context_type);
+        let abstract_text = pick_abstract(ctx);
+        // Budget for the abstract = target line length minus the fixed overhead
+        // (category tag, separator, URI, rank). Clamp to a floor so short URIs
+        // don't yield absurdly long abstracts.
+        let overhead = cat.len() + ctx.uri.len() + 20;
+        let abs_budget = COMPACT_LINE_LEN.saturating_sub(overhead).max(40);
+        let abs_short = truncate_ellipsis(abstract_text, abs_budget);
+        out.push_str(&format!(
+            "[{}] {} — {} (rank={:.2})\n",
+            cat, abs_short, ctx.uri, result.rank
+        ));
+    }
+
+    out
+}
+
+/// Length-capped context output for inline prompt injection.
+///
+/// Shape: `[category] short-abstract` lines. Overall byte count is bounded by
+/// `CONTEXT_BYTE_CAP` so that a misbehaving DB cannot blow a prompt hook's
+/// context budget.
+pub fn search_results_to_context(results: &[SearchResult]) -> String {
+    if results.is_empty() {
+        return String::new();
+    }
+
+    let mut out = String::new();
+    for result in results {
+        let ctx = &result.context;
+        let cat = ctx.category.as_deref().unwrap_or(&ctx.context_type);
+        let abstract_text = pick_abstract(ctx);
+        let abs_short = truncate_ellipsis(abstract_text, CONTEXT_LINE_LEN);
+        let line = format!("[{}] {}\n", cat, abs_short);
+        if out.len() + line.len() > CONTEXT_BYTE_CAP {
+            break;
+        }
+        out.push_str(&line);
+    }
+
+    out
+}
+
 pub fn context_record_to_markdown(ctx: &ContextRecord) -> String {
     let mut md = String::new();
     let cat = ctx.category.as_deref().unwrap_or(&ctx.context_type);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,4 +10,5 @@ pub mod jsonl;
 pub mod models;
 pub mod propagate;
 pub mod search;
+pub mod timeline;
 pub mod uri;

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,6 +87,35 @@ enum Commands {
         /// Maximum propagation hops (default 2)
         #[arg(long, default_value = "2")]
         propagate_depth: usize,
+
+        /// Output format: full (default markdown), compact (one line per hit,
+        /// ~75 tokens), or context (length-capped for prompt injection)
+        #[arg(long, default_value = "full")]
+        format: String,
+    },
+
+    /// Chronological slice of contexts around an anchor URI.
+    /// Part of the progressive-disclosure flow: search → timeline → get.
+    Timeline {
+        /// Anchor URI (e.g. rememora://projects/foo/memories/decision/x)
+        #[arg(long)]
+        anchor: String,
+
+        /// Number of contexts before the anchor
+        #[arg(long, default_value = "3")]
+        before: usize,
+
+        /// Number of contexts after the anchor
+        #[arg(long, default_value = "3")]
+        after: usize,
+
+        /// Scope filter; defaults to the anchor's own project.
+        #[arg(long)]
+        project: Option<String>,
+
+        /// Ordering: ts (creation time, default) or hotness
+        #[arg(long, default_value = "ts")]
+        by: String,
     },
 
     /// Get project context (L0 map + L1 top memories)
@@ -516,19 +545,45 @@ fn main() -> Result<()> {
             propagate,
             propagate_decay,
             propagate_depth,
-        } => commands::search::run(
-            &conn,
-            &commands::search::SearchArgs {
-                query,
-                project,
-                category,
-                limit,
-                propagate,
-                propagate_decay,
-                propagate_depth,
-            },
-            cli.json,
-        ),
+            format,
+        } => {
+            let fmt = commands::search::SearchFormat::parse(&format)?;
+            commands::search::run(
+                &conn,
+                &commands::search::SearchArgs {
+                    query,
+                    project,
+                    category,
+                    limit,
+                    propagate,
+                    propagate_decay,
+                    propagate_depth,
+                    format: fmt,
+                },
+                cli.json,
+            )
+        }
+
+        Commands::Timeline {
+            anchor,
+            before,
+            after,
+            project,
+            by,
+        } => {
+            let order = commands::timeline::TimelineOrder::parse(&by)?;
+            commands::timeline::run(
+                &conn,
+                &commands::timeline::TimelineArgs {
+                    anchor,
+                    before,
+                    after,
+                    project,
+                    by: order,
+                },
+                cli.json,
+            )
+        }
 
         Commands::Context { project, auto, cheatsheet } => {
             commands::context::run(&conn, project.as_deref(), auto, cheatsheet)

--- a/src/timeline.rs
+++ b/src/timeline.rs
@@ -1,0 +1,207 @@
+//! Library-level timeline primitives.
+//!
+//! The `rememora timeline` CLI verb is a thin wrapper over [`build_timeline`];
+//! the heavy lifting lives here so that behavior tests can exercise it
+//! without reaching into the binary crate.
+//!
+//! Timeline is the middle layer in the progressive-disclosure trio:
+//!
+//! - `search` — filter (many hits, tiny per-hit payload)
+//! - `timeline` — context (neighbours around one anchor)
+//! - `get` — full L2 content for a single URI
+
+use anyhow::{bail, Result};
+use chrono::DateTime;
+use rusqlite::Connection;
+
+use crate::hotness;
+use crate::models::context::{self, ContextRecord};
+use crate::uri;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TimelineOrder {
+    Ts,
+    Hotness,
+}
+
+impl TimelineOrder {
+    pub fn parse(s: &str) -> Result<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "ts" | "time" | "created" => Ok(Self::Ts),
+            "hotness" | "hot" => Ok(Self::Hotness),
+            other => bail!("unknown --by value: {other} (expected ts|hotness)"),
+        }
+    }
+}
+
+pub struct TimelineArgs {
+    pub anchor: String,
+    pub before: usize,
+    pub after: usize,
+    pub project: Option<String>,
+    pub by: TimelineOrder,
+}
+
+/// Rendered timeline: `before` (oldest-first for `Ts`, hottest-first for
+/// `Hotness`), then the anchor, then `after` (same ordering rule).
+#[derive(Debug)]
+pub struct Timeline {
+    pub anchor: ContextRecord,
+    pub before: Vec<ContextRecord>,
+    pub after: Vec<ContextRecord>,
+}
+
+/// Build a timeline around `args.anchor`.
+///
+/// Does NOT bump the anchor's `active_count` — callers that want the same
+/// side effect as `rememora get` should do so after build.
+pub fn build_timeline(conn: &Connection, args: &TimelineArgs) -> Result<Timeline> {
+    let anchor = match context::get_by_uri(conn, &args.anchor)? {
+        Some(c) => c,
+        None => bail!("Context not found: {}", args.anchor),
+    };
+
+    // Scope: explicit --project wins, otherwise infer from the anchor's URI.
+    // Global anchors fall back to global scope.
+    let scope_project = args
+        .project
+        .clone()
+        .or_else(|| uri::extract_project(&anchor.uri));
+
+    let peers = list_peers(conn, scope_project.as_deref(), &anchor.id)?;
+
+    let (before, after) = match args.by {
+        TimelineOrder::Ts => slice_by_ts(&anchor, peers, args.before, args.after),
+        TimelineOrder::Hotness => slice_by_hotness(peers, args.before, args.after),
+    };
+
+    Ok(Timeline {
+        anchor,
+        before,
+        after,
+    })
+}
+
+fn list_peers(
+    conn: &Connection,
+    project: Option<&str>,
+    exclude_id: &str,
+) -> Result<Vec<ContextRecord>> {
+    let mut sql = String::from(
+        "SELECT id, uri, parent_uri, context_type, category, name, abstract,
+                overview, content, tags, source_agent, source_session,
+                importance, active_count, created_at, updated_at, superseded_by
+         FROM contexts
+         WHERE superseded_by IS NULL AND id != ?1",
+    );
+
+    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+    params.push(Box::new(exclude_id.to_string()));
+
+    if let Some(proj) = project {
+        sql.push_str(
+            " AND (uri LIKE ?2 OR uri LIKE 'rememora://global/%')",
+        );
+        params.push(Box::new(format!("rememora://projects/{proj}/%")));
+    } else {
+        sql.push_str(" AND uri LIKE 'rememora://global/%'");
+    }
+
+    sql.push_str(" ORDER BY created_at ASC");
+
+    let mut stmt = conn.prepare(&sql)?;
+    let params_ref: Vec<&dyn rusqlite::types::ToSql> =
+        params.iter().map(|p| p.as_ref()).collect();
+
+    let rows = stmt
+        .query_map(params_ref.as_slice(), |row| {
+            Ok(ContextRecord {
+                id: row.get(0)?,
+                uri: row.get(1)?,
+                parent_uri: row.get(2)?,
+                context_type: row.get(3)?,
+                category: row.get(4)?,
+                name: row.get(5)?,
+                abstract_text: row.get(6)?,
+                overview: row.get(7)?,
+                content: row.get(8)?,
+                tags: row.get(9)?,
+                source_agent: row.get(10)?,
+                source_session: row.get(11)?,
+                importance: row.get(12)?,
+                active_count: row.get(13)?,
+                created_at: row.get(14)?,
+                updated_at: row.get(15)?,
+                superseded_by: row.get(16)?,
+            })
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+
+    Ok(rows)
+}
+
+fn slice_by_ts(
+    anchor: &ContextRecord,
+    peers: Vec<ContextRecord>,
+    before: usize,
+    after: usize,
+) -> (Vec<ContextRecord>, Vec<ContextRecord>) {
+    // peers are already sorted ascending by created_at.
+    let anchor_ts = anchor.created_at.as_str();
+
+    let mut older: Vec<ContextRecord> = peers
+        .iter()
+        .filter(|c| c.created_at.as_str() < anchor_ts)
+        .cloned()
+        .collect();
+    let newer: Vec<ContextRecord> = peers
+        .iter()
+        .filter(|c| c.created_at.as_str() > anchor_ts)
+        .cloned()
+        .collect();
+
+    // `older` is oldest → newest; take the newest `before` entries while
+    // preserving oldest-first display order.
+    let older_len = older.len();
+    if older_len > before {
+        older.drain(0..(older_len - before));
+    }
+
+    let after_slice: Vec<ContextRecord> = newer.into_iter().take(after).collect();
+
+    (older, after_slice)
+}
+
+fn slice_by_hotness(
+    peers: Vec<ContextRecord>,
+    before: usize,
+    after: usize,
+) -> (Vec<ContextRecord>, Vec<ContextRecord>) {
+    let mut scored: Vec<(f64, ContextRecord)> = peers
+        .into_iter()
+        .map(|c| {
+            let updated = DateTime::parse_from_rfc3339(&c.updated_at)
+                .map(|dt| dt.with_timezone(&chrono::Utc))
+                .unwrap_or_else(|_| chrono::Utc::now());
+            let score = hotness::final_score(c.importance, c.active_count, &updated);
+            (score, c)
+        })
+        .collect();
+
+    // Hottest first.
+    scored.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+
+    let top: Vec<ContextRecord> = scored
+        .into_iter()
+        .take(before + after)
+        .map(|(_, c)| c)
+        .collect();
+
+    // Split into before / after buckets. Scores are monotonically descending
+    // in `top`, so the hottest peers end up in `before`; callers display
+    // before → anchor → after so hot neighbours sit closest to the anchor.
+    let mut b = top;
+    let after_vec: Vec<ContextRecord> = b.split_off(b.len().min(before));
+    let before_vec = b;
+    (before_vec, after_vec.into_iter().take(after).collect())
+}

--- a/tests/behavior_search.rs
+++ b/tests/behavior_search.rs
@@ -136,6 +136,112 @@ fn search_for_nonexistent_term_returns_empty() {
 }
 
 // ---------------------------------------------------------------------------
+// Output formats: compact + context
+// ---------------------------------------------------------------------------
+
+#[test]
+fn compact_format_is_one_line_per_hit_with_category_uri_and_rank() {
+    // Given: two memories that should match a query
+    let conn = db_with_memories(&[
+        memory("Redis caching")
+            .project("testproj")
+            .category("decision")
+            .content("Picked Redis over Memcached for caching"),
+        memory("Redis connection pool")
+            .project("testproj")
+            .category("entity")
+            .content("Shared Redis pool lives in src/cache"),
+    ]);
+
+    // When: searching and rendering the compact format
+    let results = rememora::search::search(&conn, "redis", None, None, 10).unwrap();
+    assert!(!results.is_empty(), "expected search hits");
+
+    let rendered = rememora::format::search_results_to_compact(&results);
+    let lines: Vec<&str> = rendered.lines().collect();
+
+    // Then: one line per hit, each line carries category tag + URI + rank token
+    assert_eq!(lines.len(), results.len());
+    for (line, result) in lines.iter().zip(results.iter()) {
+        let cat = result.context.category.as_deref().unwrap_or("");
+        assert!(
+            line.starts_with(&format!("[{}]", cat)),
+            "line should start with category tag, got: {line}"
+        );
+        assert!(line.contains(&result.context.uri), "line should include URI: {line}");
+        assert!(line.contains("rank="), "line should include rank token: {line}");
+    }
+}
+
+#[test]
+fn compact_format_trims_overly_long_abstracts() {
+    // Given: a memory with an intentionally very long abstract
+    let huge = "x".repeat(2000);
+    let conn = db_with_memories(&[
+        memory("bloated abstract")
+            .project("testproj")
+            .abstract_text(&huge)
+            .content("anything"),
+    ]);
+
+    // When: searching and rendering compact
+    let results = rememora::search::search(&conn, "bloated", None, None, 10).unwrap();
+    let rendered = rememora::format::search_results_to_compact(&results);
+
+    // Then: no line keeps the full 2000-char abstract
+    for line in rendered.lines() {
+        assert!(
+            line.chars().count() < 400,
+            "compact line should be trimmed, got {} chars",
+            line.chars().count()
+        );
+    }
+}
+
+#[test]
+fn context_format_is_length_capped_for_prompt_injection() {
+    // Given: many memories so that an uncapped render would blow the budget
+    let builders: Vec<_> = (0..50)
+        .map(|i| {
+            memory(&format!("match-{i}"))
+                .project("testproj")
+                .content("prompt-injection budget test")
+        })
+        .collect();
+    let conn = db_with_memories(&builders);
+
+    // When: searching and rendering context-mode
+    let results =
+        rememora::search::search(&conn, "prompt injection budget", None, None, 50).unwrap();
+    assert!(!results.is_empty());
+    let rendered = rememora::format::search_results_to_context(&results);
+
+    // Then: overall byte count stays well under the inline-prompt cap
+    assert!(
+        rendered.len() <= 1200,
+        "context format should be capped under 1200 bytes, got {}",
+        rendered.len()
+    );
+    // And every line carries a bracketed category prefix
+    for line in rendered.lines() {
+        assert!(line.starts_with('['), "context line should start with [cat], got: {line}");
+    }
+}
+
+#[test]
+fn context_format_empty_when_no_results() {
+    // Given: an empty DB
+    let conn = db_with_memories(&[]);
+
+    // When: searching for something that won't match, then rendering context-mode
+    let results = rememora::search::search(&conn, "anything", None, None, 10).unwrap();
+    let rendered = rememora::format::search_results_to_context(&results);
+
+    // Then: empty string (no spurious header)
+    assert!(rendered.is_empty());
+}
+
+// ---------------------------------------------------------------------------
 // Active count bumping
 // ---------------------------------------------------------------------------
 

--- a/tests/behavior_timeline.rs
+++ b/tests/behavior_timeline.rs
@@ -1,0 +1,200 @@
+//! Behavior tests: `rememora timeline` — chronological slice around an anchor.
+//!
+//! Exercises `rememora::timeline::build_timeline`, the library-side primitive
+//! that the `timeline` CLI verb wraps.
+
+mod scenarios;
+
+use rememora::timeline::{self, TimelineArgs, TimelineOrder};
+use rusqlite::Connection;
+use scenarios::{db_with_memories, memory};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Backdate `contexts.created_at` so `slice_by_ts` has a deterministic order
+/// regardless of insert timing. `accessed_days_ago` only touches `updated_at`;
+/// the timeline slices on `created_at`, so we have to rewrite that too.
+fn backdate_created(conn: &Connection, uri: &str, days_ago: i64) {
+    let past = chrono::Utc::now() - chrono::Duration::days(days_ago);
+    conn.execute(
+        "UPDATE contexts SET created_at = ?1, updated_at = ?1 WHERE uri = ?2",
+        rusqlite::params![past.to_rfc3339(), uri],
+    )
+    .unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// Core slicing
+// ---------------------------------------------------------------------------
+
+#[test]
+fn timeline_returns_before_and_after_slice_around_anchor() {
+    // Given: five memories in one project, created at deterministic times
+    let conn = db_with_memories(&[
+        memory("Oldest decision").project("testproj").category("decision"),
+        memory("Older decision").project("testproj").category("decision"),
+        memory("Anchor decision").project("testproj").category("decision"),
+        memory("Newer decision").project("testproj").category("decision"),
+        memory("Newest decision").project("testproj").category("decision"),
+    ]);
+    backdate_created(&conn, "rememora://projects/testproj/memories/decision/oldest-decision", 40);
+    backdate_created(&conn, "rememora://projects/testproj/memories/decision/older-decision", 20);
+    backdate_created(&conn, "rememora://projects/testproj/memories/decision/anchor-decision", 10);
+    backdate_created(&conn, "rememora://projects/testproj/memories/decision/newer-decision", 5);
+    backdate_created(&conn, "rememora://projects/testproj/memories/decision/newest-decision", 1);
+
+    // When: building a timeline with before=2, after=2
+    let t = timeline::build_timeline(
+        &conn,
+        &TimelineArgs {
+            anchor: "rememora://projects/testproj/memories/decision/anchor-decision".into(),
+            before: 2,
+            after: 2,
+            project: None,
+            by: TimelineOrder::Ts,
+        },
+    )
+    .unwrap();
+
+    // Then: anchor is the middle memory, before holds the two older items
+    // (oldest-first), after holds the two newer items (oldest-first)
+    assert_eq!(t.anchor.name, "Anchor decision");
+    assert_eq!(
+        t.before.iter().map(|c| c.name.as_str()).collect::<Vec<_>>(),
+        vec!["Oldest decision", "Older decision"]
+    );
+    assert_eq!(
+        t.after.iter().map(|c| c.name.as_str()).collect::<Vec<_>>(),
+        vec!["Newer decision", "Newest decision"]
+    );
+}
+
+#[test]
+fn timeline_respects_before_after_limits() {
+    // Given: several memories, but only 1 wanted on each side
+    let conn = db_with_memories(&[
+        memory("A").project("testproj"),
+        memory("B").project("testproj"),
+        memory("Anchor").project("testproj"),
+        memory("C").project("testproj"),
+        memory("D").project("testproj"),
+    ]);
+    backdate_created(&conn, "rememora://projects/testproj/memories/decision/a", 40);
+    backdate_created(&conn, "rememora://projects/testproj/memories/decision/b", 20);
+    backdate_created(&conn, "rememora://projects/testproj/memories/decision/anchor", 10);
+    backdate_created(&conn, "rememora://projects/testproj/memories/decision/c", 5);
+    backdate_created(&conn, "rememora://projects/testproj/memories/decision/d", 1);
+
+    // When: before=1, after=1
+    let t = timeline::build_timeline(
+        &conn,
+        &TimelineArgs {
+            anchor: "rememora://projects/testproj/memories/decision/anchor".into(),
+            before: 1,
+            after: 1,
+            project: None,
+            by: TimelineOrder::Ts,
+        },
+    )
+    .unwrap();
+
+    // Then: only the closest neighbour on each side is returned
+    assert_eq!(t.before.len(), 1);
+    assert_eq!(t.before[0].name, "B"); // newest-older
+    assert_eq!(t.after.len(), 1);
+    assert_eq!(t.after[0].name, "C"); // oldest-newer
+}
+
+#[test]
+fn timeline_by_hotness_prefers_hot_neighbours() {
+    // Given: peers with different hotness; anchor in the middle chronologically
+    // but we explicitly request hotness ordering
+    let conn = db_with_memories(&[
+        memory("cold-a").project("testproj").importance(0.1).access_count(0),
+        memory("hot-b").project("testproj").importance(0.9).access_count(100),
+        memory("anchor").project("testproj"),
+        memory("cold-c").project("testproj").importance(0.1).access_count(0),
+        memory("hot-d").project("testproj").importance(0.9).access_count(100),
+    ]);
+
+    // When: building a hotness-ordered timeline of size 2
+    let t = timeline::build_timeline(
+        &conn,
+        &TimelineArgs {
+            anchor: "rememora://projects/testproj/memories/decision/anchor".into(),
+            before: 1,
+            after: 1,
+            project: None,
+            by: TimelineOrder::Hotness,
+        },
+    )
+    .unwrap();
+
+    // Then: both slots go to the hot memories, cold ones are excluded
+    let all_names: Vec<&str> = t
+        .before
+        .iter()
+        .chain(t.after.iter())
+        .map(|c| c.name.as_str())
+        .collect();
+    assert!(all_names.contains(&"hot-b"), "hot-b should appear in timeline, got {all_names:?}");
+    assert!(all_names.contains(&"hot-d"), "hot-d should appear in timeline, got {all_names:?}");
+    assert!(!all_names.contains(&"cold-a"), "cold-a should not beat hot peers");
+    assert!(!all_names.contains(&"cold-c"), "cold-c should not beat hot peers");
+}
+
+#[test]
+fn timeline_missing_anchor_errors() {
+    // Given: an empty DB
+    let conn = db_with_memories(&[]);
+
+    // When: asking for a timeline around a URI that isn't there
+    let err = timeline::build_timeline(
+        &conn,
+        &TimelineArgs {
+            anchor: "rememora://projects/nope/memories/decision/ghost".into(),
+            before: 3,
+            after: 3,
+            project: None,
+            by: TimelineOrder::Ts,
+        },
+    )
+    .unwrap_err();
+
+    // Then: error mentions the missing URI
+    let msg = err.to_string();
+    assert!(msg.contains("Context not found"), "unexpected error: {msg}");
+}
+
+#[test]
+fn timeline_scopes_peers_to_anchor_project() {
+    // Given: one memory in project-alpha (the anchor) and one in project-beta
+    let conn = db_with_memories(&[
+        memory("anchor").project("alpha"),
+        memory("stranger").project("beta"),
+    ]);
+
+    // When: building a timeline around the alpha anchor
+    let t = timeline::build_timeline(
+        &conn,
+        &TimelineArgs {
+            anchor: "rememora://projects/alpha/memories/decision/anchor".into(),
+            before: 3,
+            after: 3,
+            project: None,
+            by: TimelineOrder::Ts,
+        },
+    )
+    .unwrap();
+
+    // Then: the beta memory is not pulled into the timeline
+    let all_names: Vec<&str> = t
+        .before
+        .iter()
+        .chain(t.after.iter())
+        .map(|c| c.name.as_str())
+        .collect();
+    assert!(!all_names.contains(&"stranger"), "peer leaked across project boundary: {all_names:?}");
+}


### PR DESCRIPTION
Closes #80.

## Summary

Bind the existing L0/L1/L2 tiers to distinct CLI verbs so agents can filter
cheaply before paying the full token cost of a memory. Three pieces:

1. `rememora search --format <full|compact|context>`
   - `full` (default, current behavior — avoids script breakage)
   - `compact` — one line per hit, ~75 tokens each:
     `[cat] abstract — rememora://... (rank=-1.23)`
   - `context` — byte-capped (<=1200 B) for inline prompt injection,
     pre-wiring the hook in #77
2. `rememora timeline --anchor <uri> [--before N] [--after N]
   [--project P] [--by ts|hotness]` — chronological (or hotness-ranked)
   slice of contexts around an anchor URI.
3. Plugin `rememora-search` SKILL rewritten around the 3-layer workflow:
   `search` (filter) → `timeline` (context) → `get` (full content), with
   a worked example.

## Design notes

- Library-level timeline primitives live in `src/timeline.rs`; the CLI in
  `src/commands/timeline.rs` is a thin wrapper (mirrors the evolve pattern)
  so behavior tests can exercise the logic without the binary crate.
- `timeline` default ordering: `ts` (creation time). `--by hotness` uses
  the existing `hotness::final_score` (importance blended with hotness).
- `timeline` bumps the anchor's `active_count` — same side effect as
  `rememora get`, which matters for future hotness ranking.
- `timeline` scope: explicit `--project` wins, otherwise infers scope from
  the anchor URI; global anchors fall back to global.
- `search_results_to_compact` trims the abstract to ~140 chars to hold
  the per-hit token budget even on long abstracts.

## Test plan

- [x] `cargo test` — all suites green (including new `behavior_timeline.rs`
      and new cases in `behavior_search.rs`)
- [x] `cargo clippy --lib --bins -- -D warnings` — clean
- [x] `rememora search --help` / `rememora timeline --help` render correctly

## Report back to the tracker

- `--format compact` is **not** the default yet (stays `full`); flip is a
  follow-up release as the issue calls out.
- Timeline default ordering: `ts` (creation time). `--by hotness` optional.
- Data-model gaps that need a separate ticket: none encountered. The
  existing `contexts.created_at` / `updated_at` / `active_count` were
  enough to build the timeline.

## Coordination with #77

#77 also plans a `--format context` mode for the `UserPromptSubmit`
prompt hook. This PR ships it now (byte-capped, one-line-per-hit) so #77
only needs to wire the hook script. If #77 lands first, the
`SearchFormat::Context` branch is already an extension point they can
hang their work off.