### PR TITLE
feat(watch-transcript): Codex rollout curation (#81, Phase 1)

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -20,3 +20,4 @@ pub mod status;
 pub mod supersede;
 pub mod tui;
 pub mod usage;
+pub mod watch_transcript;

--- a/src/commands/watch_transcript.rs
+++ b/src/commands/watch_transcript.rs
@@ -1,0 +1,245 @@
+//! `rememora watch-transcript` — curate non-Claude agent session JSONL.
+//!
+//! Phase 1: Codex only, one-shot by default, optional `--follow` mode that
+//! polls the file every 500 ms for new content. **Not a daemon.** The user
+//! runs this per session; there is no launchd/systemd integration, no plugin
+//! hook, no HTTP server, no persistent background worker.
+
+use anyhow::{bail, Result};
+use rusqlite::Connection;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use rememora::curator::{self, Signal};
+use rememora::jsonl_codex;
+use rememora::models::agent_invocation::{self, Caller};
+use rememora::models::watermark;
+
+/// How often `--follow` mode re-checks the file for new content.
+const FOLLOW_POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+pub struct WatchTranscriptArgs {
+    /// Agent kind. Only `codex` is supported in Phase 1.
+    pub agent: String,
+    /// Path to the rollout JSONL.
+    pub path: PathBuf,
+    /// If set, poll the file for new content after each pass.
+    pub follow: bool,
+    /// Project name override. Falls back to `session_meta.cwd` basename from
+    /// the rollout, then to `"unknown"`.
+    pub project: Option<String>,
+    /// If true, curator shows what it *would* do without executing.
+    pub dry_run: bool,
+}
+
+pub fn run(conn: &Connection, args: &WatchTranscriptArgs, json_output: bool) -> Result<()> {
+    if !args.agent.eq_ignore_ascii_case("codex") {
+        bail!(
+            "Phase 1 supports --agent codex only (got: {}). Gemini CLI and a \
+             declarative --schema option are tracked as Phase 2.",
+            args.agent
+        );
+    }
+
+    if !args.path.exists() {
+        bail!("Transcript file not found: {}", args.path.display());
+    }
+
+    // One-shot pass first. `--follow` wraps it in a polling loop that honors
+    // the watermark — the pass is always incremental.
+    loop {
+        run_once(conn, args, json_output)?;
+
+        if !args.follow {
+            break;
+        }
+
+        std::thread::sleep(FOLLOW_POLL_INTERVAL);
+    }
+
+    Ok(())
+}
+
+fn run_once(conn: &Connection, args: &WatchTranscriptArgs, json_output: bool) -> Result<()> {
+    let path_str = args.path.to_string_lossy();
+
+    let offset = watermark::get(conn, &path_str)?
+        .map(|w| w.byte_offset)
+        .unwrap_or(0);
+
+    let parse_result = jsonl_codex::parse_file(&args.path, offset)?;
+
+    if parse_result.entries.is_empty() {
+        // No new content — in --follow mode this is the common case. Stay
+        // quiet unless the user asked for JSON.
+        if json_output && !args.follow {
+            println!(
+                "{{\"status\":\"no_new_content\",\"file\":\"{path_str}\",\"offset\":{offset}}}"
+            );
+        }
+        return Ok(());
+    }
+
+    let transcript = jsonl_codex::render_transcript(&parse_result.entries);
+
+    if !json_output {
+        eprintln!(
+            "  {} — {} entries, {} lines from offset {}{}",
+            path_str,
+            parse_result.entries.len(),
+            parse_result.lines_processed,
+            offset,
+            if parse_result.truncated {
+                " (truncated)"
+            } else {
+                ""
+            }
+        );
+    }
+
+    // Signal gate (Haiku).
+    let gate = curator::signal_gate(&transcript)?;
+    let project_for_telemetry = resolve_project(args, &parse_result.cwd, &args.path);
+    if let Some(t) = &gate.telemetry {
+        agent_invocation::try_insert(
+            conn,
+            &agent_invocation::record_from_subagent(
+                Caller::SignalGate,
+                Some(project_for_telemetry.clone()),
+                None,
+                t,
+            ),
+        );
+    }
+
+    if gate.signal == Signal::No {
+        watermark::set(
+            conn,
+            &path_str,
+            parse_result.new_offset,
+            parse_result.lines_processed as u64,
+        )?;
+        watermark::log_action(conn, &path_str, "noop", None, "No signal (codex)", "")?;
+        if !json_output {
+            eprintln!("    → no signal, skipping");
+        }
+        return Ok(());
+    }
+
+    if !json_output {
+        eprintln!(
+            "    → signal detected, curating for project '{}'...",
+            project_for_telemetry
+        );
+    }
+
+    let result = curator::curate(&transcript, &project_for_telemetry, args.dry_run)?;
+
+    if let Some(t) = &result.telemetry {
+        agent_invocation::try_insert(
+            conn,
+            &agent_invocation::record_from_subagent(
+                Caller::Curator,
+                Some(project_for_telemetry.clone()),
+                None,
+                t,
+            ),
+        );
+    }
+
+    watermark::set(
+        conn,
+        &path_str,
+        parse_result.new_offset,
+        parse_result.lines_processed as u64,
+    )?;
+
+    let action = if args.dry_run { "noop" } else { "add" };
+    let reason = result.curator_output.as_deref().unwrap_or("");
+    let log_reason = if reason.len() > 500 {
+        &reason[..500]
+    } else {
+        reason
+    };
+    watermark::log_action(conn, &path_str, action, None, log_reason, "sonnet")?;
+
+    if json_output {
+        let output = serde_json::json!({
+            "agent": "codex",
+            "file": path_str,
+            "signal": "yes",
+            "dry_run": args.dry_run,
+            "entries_processed": parse_result.entries.len(),
+            "project": project_for_telemetry,
+            "curator_output": result.curator_output,
+        });
+        println!("{}", serde_json::to_string(&output)?);
+    } else if let Some(out) = &result.curator_output {
+        println!("{out}");
+    }
+
+    Ok(())
+}
+
+/// Project resolution order: explicit `--project` → `session_meta.cwd`
+/// basename → path-based fallback → `"unknown"`.
+fn resolve_project(args: &WatchTranscriptArgs, cwd: &Option<String>, path: &Path) -> String {
+    if let Some(p) = args.project.as_deref() {
+        return p.to_string();
+    }
+    if let Some(cwd) = cwd.as_deref() {
+        if let Some(basename) = std::path::Path::new(cwd).file_name().and_then(|s| s.to_str()) {
+            if !basename.is_empty() {
+                return basename.to_string();
+            }
+        }
+    }
+    if let Some(basename) = path.file_stem().and_then(|s| s.to_str()) {
+        return basename.to_string();
+    }
+    "unknown".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn project_prefers_explicit_override() {
+        let args = WatchTranscriptArgs {
+            agent: "codex".into(),
+            path: PathBuf::from("/tmp/session.jsonl"),
+            follow: false,
+            project: Some("my-app".into()),
+            dry_run: false,
+        };
+        let got = resolve_project(&args, &Some("/Users/me/other".into()), &args.path);
+        assert_eq!(got, "my-app");
+    }
+
+    #[test]
+    fn project_falls_back_to_session_cwd_basename() {
+        let args = WatchTranscriptArgs {
+            agent: "codex".into(),
+            path: PathBuf::from("/tmp/session.jsonl"),
+            follow: false,
+            project: None,
+            dry_run: false,
+        };
+        let got = resolve_project(&args, &Some("/Users/me/homeserver".into()), &args.path);
+        assert_eq!(got, "homeserver");
+    }
+
+    #[test]
+    fn project_falls_back_to_file_stem_when_no_cwd() {
+        let args = WatchTranscriptArgs {
+            agent: "codex".into(),
+            path: PathBuf::from("/tmp/session.jsonl"),
+            follow: false,
+            project: None,
+            dry_run: false,
+        };
+        let got = resolve_project(&args, &None, &args.path);
+        assert_eq!(got, "session");
+    }
+}

--- a/src/jsonl_codex.rs
+++ b/src/jsonl_codex.rs
@@ -1,0 +1,404 @@
+//! Parser for Codex CLI session JSONL rollout files.
+//!
+//! Codex sessions live at `~/.codex/sessions/YYYY/MM/DD/rollout-<id>.jsonl`.
+//! Each line is `{timestamp, type, payload}`. We extract only the conversation
+//! shape the curator needs: user/assistant messages, tool calls, tool outputs.
+//!
+//! Everything else — `reasoning` (private thinking), `event_msg` (mirrors
+//! response_item; would double-count), `turn_context`, `compacted` — is
+//! skipped. `session_meta` is mined only for `cwd` → project name.
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
+use std::path::Path;
+
+/// Maximum condensed transcript size in bytes (~32 KB) — matches `jsonl.rs`.
+const MAX_TRANSCRIPT_BYTES: usize = 32_768;
+
+/// Maximum preview length for a single function call argument blob.
+const TOOL_PREVIEW_LEN: usize = 200;
+
+// ── Raw JSONL line shapes (payload is type-tagged) ──────────────────
+
+#[derive(Deserialize)]
+struct RawLine {
+    #[serde(rename = "type")]
+    line_type: String,
+    #[serde(default)]
+    payload: serde_json::Value,
+}
+
+// ── Public types ────────────────────────────────────────────────────
+
+/// A condensed transcript entry from a Codex rollout.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TranscriptEntry {
+    pub role: String,
+    pub text: String,
+}
+
+/// Result of parsing a Codex rollout from a given byte offset.
+#[derive(Debug)]
+pub struct ParseResult {
+    pub entries: Vec<TranscriptEntry>,
+    /// Working directory captured from `session_meta` (if present), used as a
+    /// project-name fallback when the caller doesn't pass `--project`.
+    pub cwd: Option<String>,
+    /// New byte offset (end of file after reading).
+    pub new_offset: u64,
+    /// Number of raw JSONL lines processed.
+    pub lines_processed: usize,
+    /// True if the transcript was truncated to fit the byte cap.
+    pub truncated: bool,
+}
+
+// ── Public API ──────────────────────────────────────────────────────
+
+/// Parse a Codex rollout JSONL file starting at `byte_offset`.
+pub fn parse_file(path: &Path, byte_offset: u64) -> Result<ParseResult> {
+    let mut file = std::fs::File::open(path)
+        .with_context(|| format!("Failed to open Codex JSONL: {}", path.display()))?;
+
+    let file_len = file.metadata()?.len();
+    if byte_offset >= file_len {
+        return Ok(ParseResult {
+            entries: vec![],
+            cwd: None,
+            new_offset: file_len,
+            lines_processed: 0,
+            truncated: false,
+        });
+    }
+
+    file.seek(SeekFrom::Start(byte_offset))?;
+    let mut result = parse_reader(file)?;
+    result.new_offset += byte_offset;
+    Ok(result)
+}
+
+/// Parse Codex JSONL from any reader (useful for tests).
+pub fn parse_reader<R: Read>(reader: R) -> Result<ParseResult> {
+    let buf = BufReader::new(reader);
+    let mut entries: Vec<TranscriptEntry> = Vec::new();
+    let mut cwd: Option<String> = None;
+    let mut total_bytes: usize = 0;
+    let mut lines_processed: usize = 0;
+    let mut bytes_consumed: u64 = 0;
+    let mut truncated = false;
+
+    for line_result in buf.lines() {
+        let line = line_result?;
+        bytes_consumed += line.len() as u64 + 1; // +1 for the stripped newline
+        lines_processed += 1;
+
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let raw: RawLine = match serde_json::from_str(&line) {
+            Ok(r) => r,
+            Err(_) => continue, // skip malformed lines — non-fatal
+        };
+
+        // session_meta: pull cwd once.
+        if raw.line_type == "session_meta" && cwd.is_none() {
+            cwd = raw
+                .payload
+                .get("cwd")
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+            continue;
+        }
+
+        // response_item is the only carrier of conversation signal. Everything
+        // else (event_msg, turn_context, reasoning, compacted) is deliberately
+        // skipped — event_msg in particular would double-count messages.
+        if raw.line_type != "response_item" {
+            continue;
+        }
+
+        let Some(entry) = condense_response_item(&raw.payload) else {
+            continue;
+        };
+
+        let entry_len = entry.role.len() + entry.text.len() + 4; // ": \n\n"
+        if total_bytes + entry_len > MAX_TRANSCRIPT_BYTES {
+            truncated = true;
+            break;
+        }
+
+        total_bytes += entry_len;
+        entries.push(entry);
+    }
+
+    Ok(ParseResult {
+        entries,
+        cwd,
+        new_offset: bytes_consumed,
+        lines_processed,
+        truncated,
+    })
+}
+
+/// Render the transcript entries into the curator prompt string.
+pub fn render_transcript(entries: &[TranscriptEntry]) -> String {
+    let mut out = String::new();
+    for entry in entries {
+        out.push_str(&entry.role);
+        out.push_str(": ");
+        out.push_str(&entry.text);
+        out.push_str("\n\n");
+    }
+    out
+}
+
+// ── Internals ───────────────────────────────────────────────────────
+
+fn condense_response_item(payload: &serde_json::Value) -> Option<TranscriptEntry> {
+    let obj = payload.as_object()?;
+    let item_type = obj.get("type")?.as_str()?;
+
+    match item_type {
+        "message" => condense_message(obj),
+        "function_call" => condense_function_call(obj),
+        "function_call_output" => condense_function_call_output(obj),
+        // Skip: reasoning (private thinking), compacted (summarization marker),
+        // custom_instructions, everything else.
+        _ => None,
+    }
+}
+
+fn condense_message(obj: &serde_json::Map<String, serde_json::Value>) -> Option<TranscriptEntry> {
+    let role = obj.get("role")?.as_str()?.to_string();
+    let content = obj.get("content")?.as_array()?;
+
+    let mut parts: Vec<String> = Vec::new();
+    for c in content {
+        let ct = c.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        // Codex uses input_text for user messages, output_text for assistant;
+        // some variants emit plain "text".
+        if matches!(ct, "input_text" | "output_text" | "text") {
+            if let Some(t) = c.get("text").and_then(|v| v.as_str()) {
+                let cleaned = strip_environment_context(t);
+                if !cleaned.is_empty() {
+                    parts.push(cleaned);
+                }
+            }
+        }
+    }
+
+    if parts.is_empty() {
+        return None;
+    }
+
+    Some(TranscriptEntry {
+        role,
+        text: parts.join("\n"),
+    })
+}
+
+fn condense_function_call(
+    obj: &serde_json::Map<String, serde_json::Value>,
+) -> Option<TranscriptEntry> {
+    let name = obj.get("name").and_then(|v| v.as_str()).unwrap_or("unknown");
+    let args = obj
+        .get("arguments")
+        .and_then(|v| v.as_str())
+        .map(|s| truncate_str(s, TOOL_PREVIEW_LEN))
+        .unwrap_or_default();
+
+    Some(TranscriptEntry {
+        role: "assistant".to_string(),
+        text: format!("[tool: {name}({args})]"),
+    })
+}
+
+fn condense_function_call_output(
+    obj: &serde_json::Map<String, serde_json::Value>,
+) -> Option<TranscriptEntry> {
+    let call_id = obj
+        .get("call_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+
+    Some(TranscriptEntry {
+        role: "user".to_string(),
+        text: format!("[tool_result: {call_id}]"),
+    })
+}
+
+/// Codex prefixes user turns with `<environment_context>...</environment_context>`
+/// blocks that add no signal for curation. Strip them the same way the Claude
+/// Code parser strips `<system-reminder>` blocks.
+fn strip_environment_context(s: &str) -> String {
+    let mut result = s.to_string();
+    for tag in &["environment_context", "user_instructions"] {
+        let open = format!("<{tag}>");
+        let close = format!("</{tag}>");
+        while let Some(start) = result.find(&open) {
+            if let Some(end) = result.find(&close) {
+                let end = end + close.len();
+                result.replace_range(start..end, "");
+            } else {
+                result.truncate(start);
+                break;
+            }
+        }
+    }
+    result.trim().to_string()
+}
+
+fn truncate_str(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}…", &s[..max])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    fn parse_lines(lines: &[&str]) -> ParseResult {
+        let data = lines.join("\n");
+        parse_reader(Cursor::new(data.into_bytes())).unwrap()
+    }
+
+    #[test]
+    fn session_meta_yields_cwd() {
+        let line = r#"{"timestamp":"2026-01-01T00:00:00Z","type":"session_meta","payload":{"id":"s1","cwd":"/Users/me/proj","originator":"codex_cli_rs","cli_version":"0.42.0"}}"#;
+        let r = parse_lines(&[line]);
+        assert_eq!(r.cwd.as_deref(), Some("/Users/me/proj"));
+        assert!(r.entries.is_empty());
+    }
+
+    #[test]
+    fn user_message_is_captured() {
+        let line = r#"{"timestamp":"2026-01-01T00:00:00Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"hello"}]}}"#;
+        let r = parse_lines(&[line]);
+        assert_eq!(r.entries.len(), 1);
+        assert_eq!(r.entries[0].role, "user");
+        assert_eq!(r.entries[0].text, "hello");
+    }
+
+    #[test]
+    fn assistant_output_text_is_captured() {
+        let line = r#"{"timestamp":"2026-01-01T00:00:01Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"world"}]}}"#;
+        let r = parse_lines(&[line]);
+        assert_eq!(r.entries.len(), 1);
+        assert_eq!(r.entries[0].role, "assistant");
+        assert_eq!(r.entries[0].text, "world");
+    }
+
+    #[test]
+    fn reasoning_is_skipped() {
+        let line = r#"{"timestamp":"2026-01-01T00:00:01Z","type":"response_item","payload":{"type":"reasoning","summary":"thinking","content":"x"}}"#;
+        let r = parse_lines(&[line]);
+        assert_eq!(r.entries.len(), 0);
+    }
+
+    #[test]
+    fn event_msg_is_skipped_to_avoid_double_count() {
+        // event_msg mirrors response_item and would double-count messages.
+        let msg = r#"{"timestamp":"2026-01-01T00:00:00Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}}"#;
+        let dup = r#"{"timestamp":"2026-01-01T00:00:00Z","type":"event_msg","payload":{"type":"user_turn","text":"hi"}}"#;
+        let r = parse_lines(&[msg, dup]);
+        assert_eq!(r.entries.len(), 1);
+    }
+
+    #[test]
+    fn function_call_condenses_to_tool_marker() {
+        let line = r#"{"timestamp":"2026-01-01T00:00:00Z","type":"response_item","payload":{"type":"function_call","name":"shell","arguments":"{\"command\":\"ls\"}","call_id":"c1"}}"#;
+        let r = parse_lines(&[line]);
+        assert_eq!(r.entries.len(), 1);
+        assert_eq!(r.entries[0].role, "assistant");
+        assert!(r.entries[0].text.starts_with("[tool: shell("));
+        assert!(r.entries[0].text.contains("ls"));
+    }
+
+    #[test]
+    fn function_call_output_condenses_to_tool_result_marker() {
+        let line = r#"{"timestamp":"2026-01-01T00:00:00Z","type":"response_item","payload":{"type":"function_call_output","call_id":"c1","output":"done"}}"#;
+        let r = parse_lines(&[line]);
+        assert_eq!(r.entries.len(), 1);
+        assert_eq!(r.entries[0].role, "user");
+        assert!(r.entries[0].text.starts_with("[tool_result: c1"));
+    }
+
+    #[test]
+    fn environment_context_tags_are_stripped() {
+        let line = r#"{"timestamp":"2026-01-01T00:00:00Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<environment_context>\n  <cwd>/tmp</cwd>\n</environment_context>\nactual prompt"}]}}"#;
+        let r = parse_lines(&[line]);
+        assert_eq!(r.entries.len(), 1);
+        assert_eq!(r.entries[0].text, "actual prompt");
+    }
+
+    #[test]
+    fn turn_context_and_compacted_are_skipped() {
+        let tc = r#"{"timestamp":"2026-01-01T00:00:00Z","type":"turn_context","payload":{"tokens":42}}"#;
+        let cp = r#"{"timestamp":"2026-01-01T00:00:00Z","type":"compacted","payload":{"summary":"x"}}"#;
+        let r = parse_lines(&[tc, cp]);
+        assert_eq!(r.entries.len(), 0);
+    }
+
+    #[test]
+    fn malformed_lines_are_skipped_without_bailing() {
+        let good = r#"{"timestamp":"2026-01-01T00:00:00Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"ok"}]}}"#;
+        let r = parse_lines(&["not json", good, ""]);
+        assert_eq!(r.entries.len(), 1);
+        assert_eq!(r.entries[0].text, "ok");
+    }
+
+    #[test]
+    fn truncation_caps_total_bytes() {
+        let big = "x".repeat(20_000);
+        let line = format!(
+            r#"{{"timestamp":"2026-01-01T00:00:00Z","type":"response_item","payload":{{"type":"message","role":"user","content":[{{"type":"input_text","text":"{big}"}}]}}}}"#
+        );
+        let r = parse_lines(&[&line, &line, &line]);
+        assert!(r.truncated);
+        assert!(r.entries.len() < 3);
+    }
+
+    #[test]
+    fn render_transcript_matches_claude_format() {
+        let entries = vec![
+            TranscriptEntry {
+                role: "user".into(),
+                text: "hi".into(),
+            },
+            TranscriptEntry {
+                role: "assistant".into(),
+                text: "hello".into(),
+            },
+        ];
+        assert_eq!(render_transcript(&entries), "user: hi\n\nassistant: hello\n\n");
+    }
+
+    #[test]
+    fn file_parse_with_offset() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("codex.jsonl");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(
+            f,
+            r#"{{"timestamp":"2026-01-01T00:00:00Z","type":"response_item","payload":{{"type":"message","role":"user","content":[{{"type":"input_text","text":"first"}}]}}}}"#
+        )
+        .unwrap();
+        let offset = f.metadata().unwrap().len();
+        writeln!(
+            f,
+            r#"{{"timestamp":"2026-01-01T00:00:01Z","type":"response_item","payload":{{"type":"message","role":"user","content":[{{"type":"input_text","text":"second"}}]}}}}"#
+        )
+        .unwrap();
+        drop(f);
+
+        let r = parse_file(&path, offset).unwrap();
+        assert_eq!(r.entries.len(), 1);
+        assert_eq!(r.entries[0].text, "second");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod format;
 pub mod hierarchy;
 pub mod hotness;
 pub mod jsonl;
+pub mod jsonl_codex;
 pub mod models;
 pub mod propagate;
 pub mod search;

--- a/src/main.rs
+++ b/src/main.rs
@@ -233,6 +233,29 @@ enum Commands {
         once: bool,
     },
 
+    /// Curate memories from a non-Claude agent's session JSONL (Phase 1: Codex only)
+    WatchTranscript {
+        /// Agent kind. Phase 1 only supports `codex`.
+        #[arg(long)]
+        agent: String,
+
+        /// Path to the rollout JSONL (e.g. ~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl)
+        #[arg(long)]
+        path: std::path::PathBuf,
+
+        /// Poll the file for new content every ~500ms. Not a daemon; runs until Ctrl+C.
+        #[arg(long)]
+        follow: bool,
+
+        /// Project scope override. Defaults to session_meta.cwd basename, then file stem.
+        #[arg(long)]
+        project: Option<String>,
+
+        /// Show what the curator would do without modifying memory.
+        #[arg(long)]
+        dry_run: bool,
+    },
+
     /// Curate memories from Claude Code session transcripts
     Curate {
         /// Path to a specific JSONL file
@@ -684,6 +707,24 @@ fn main() -> Result<()> {
                 dry_run,
                 reset_watermark,
                 project,
+            },
+            cli.json,
+        ),
+
+        Commands::WatchTranscript {
+            agent,
+            path,
+            follow,
+            project,
+            dry_run,
+        } => commands::watch_transcript::run(
+            &conn,
+            &commands::watch_transcript::WatchTranscriptArgs {
+                agent,
+                path,
+                follow,
+                project,
+                dry_run,
             },
             cli.json,
         ),


### PR DESCRIPTION
## Summary

\"Cross-agent memory\" has been our pitch; this PR makes it real for Codex. Curate memories from Codex CLI session JSONLs (\`~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl\`) through the same signal_gate → curator pipeline Claude Code already uses.

Closes #81 (Phase 1).

## New CLI

\`\`\`bash
rememora watch-transcript --agent codex --path <jsonl>
                          [--follow] [--project X] [--dry-run]
\`\`\`

- \`--agent codex\` — only value supported in Phase 1; Gemini CLI and a declarative \`--schema\` flag are tracked for Phase 2
- \`--follow\` — polls the file every 500ms. **Not a daemon** — plain loop controlled by the user's terminal. No launchd, no plugin hook, no HTTP server
- \`--project\` override; defaults to \`session_meta.cwd\` basename → file stem → \`\"unknown\"\`
- Reuses existing \`watermarks\`, \`agent_invocations\`, and curator prompts — no schema changes

## Codex JSONL parser (\`src/jsonl_codex.rs\`)

Condenses each line by \`type\`:

| type | handling |
|---|---|
| \`session_meta\` | capture \`cwd\` for project fallback |
| \`response_item.message\` | user/assistant text (\`input_text\`/\`output_text\`) |
| \`response_item.function_call\` | \`[tool: name(args)]\` marker |
| \`response_item.function_call_output\` | \`[tool_result: call_id]\` marker |
| \`response_item.reasoning\` | skipped (private thinking) |
| \`event_msg\` | skipped (mirrors \`response_item\`; would double-count) |
| \`turn_context\`, \`compacted\` | skipped |

Output matches the Claude-side \`jsonl::render_transcript\` format so the existing signal-gate and curator prompts need no changes.

## Anti-patterns explicitly NOT introduced

- Persistent watcher process / daemon
- Plugin hook on Codex sessions (Codex doesn't have hooks, and we wouldn't add one)
- HTTP server
- launchd/systemd integration
- Schema inference / auto-detection — hand-written parser for Codex only

## Test plan

- [x] 13 new parser unit tests covering session_meta/cwd, user message, assistant output_text, reasoning skip, event_msg double-count suppression, function_call/function_call_output condensation, environment_context tag stripping, turn_context/compacted skip, malformed-line tolerance, byte-cap truncation, rendered transcript format, file offset parsing
- [x] 3 CLI unit tests for project resolution (explicit override / cwd basename / file stem fallback)
- [x] \`cargo test --lib\` — 58 pass
- [x] \`cargo clippy --lib --bins -- -D warnings\` — clean
- [x] \`rememora watch-transcript --help\` — renders
- [ ] Manual: run against a real \`~/.codex/sessions/.../rollout-*.jsonl\`, verify signal-gate fires and curator produces reasonable memories

## Phase 2 backlog

- Gemini CLI JSONL support
- Declarative \`--schema path/to/schema.json\` flag
- Auto-discovery of \`~/.codex/sessions\` (like Claude Code's \`--auto\`)
- inotify/FSEvents for \`--follow\` (currently 500ms polling)