### PR TITLE
feat(telemetry): OTEL export layer over agent_invocations (#76)

### DIFF
--- a/.agents/plans/76-otel-export.md
+++ b/.agents/plans/76-otel-export.md
@@ -1,0 +1,87 @@
+# Issue #76 — Thin OTEL export layer over agent_invocations
+
+**Ticket:** https://github.com/Rememora/rememora/issues/76
+
+## Summary
+
+Add a CLI verb `rememora telemetry export-otlp` that reads from the existing
+`agent_invocations` table (migration 004) and emits OTEL-compatible JSON spans
+on demand. Export-on-demand only — no daemon, no remote push. Keeps OTEL as a
+view/interop concern over the single source of truth that `rememora usage`
+already aggregates.
+
+## Implementation Steps
+
+### 1. New module `src/commands/telemetry.rs`
+
+Add an `export_otlp` handler mirroring the filter plumbing of `usage.rs`:
+
+- `TelemetryExportArgs { since, caller, project, parent_session, format }`
+- `format` accepts `jsonl` (default — one OTLP span JSON per line) and
+  `otlp` (single OTLP HTTP/JSON doc with resourceSpans/scopeSpans/spans).
+- Replicate `parse_since` locally to avoid changing `usage.rs` signature.
+- Call a new reader `agent_invocation::list_invocations(conn, filters)`.
+- For each row, build a span via `row_to_span`:
+  - `trace_id` = 16-byte hex from `blake3(parent_session || "rememora-trace")`
+    with fallback to `blake3(id || "rememora-trace-orphan")` when
+    `parent_session` is null.
+  - `span_id` = 8-byte hex from `blake3(id || "rememora-span")`.
+  - `name` = caller-specific: signal_gate → `rememora.signal_gate.run`,
+    curator → `rememora.curator.run`, extract → `rememora.extract.run`,
+    evolve → `rememora.evolve.consolidate_cluster`, consolidate →
+    `rememora.consolidate.run`, agent_run → `rememora.agent_run.attempt`.
+    Unknown callers fall back to `rememora.<caller>.run`.
+  - `start_time_unix_nano` = RFC3339(ts) in nanos.
+  - `end_time_unix_nano` = start + duration_ms*1_000_000 (start when null).
+  - `status.code` = STATUS_CODE_ERROR if is_error else STATUS_CODE_OK.
+  - Attributes: gen_ai.system=anthropic; gen_ai.request.model;
+    gen_ai.usage.{input,output,cache_read,cache_creation}_tokens;
+    gen_ai.response.cost_usd; gen_ai.response.stop_reason;
+    rememora.{caller,project,parent_session,child_session,
+    terminal_reason,num_turns}. Nulls omitted.
+- Resource: service.name=rememora, service.version=env!("CARGO_PKG_VERSION").
+- JSONL mode: one compact JSON span per stdout line.
+- OTLP mode: single pretty JSON object.
+
+### 2. Reader in `src/models/agent_invocation.rs`
+
+Add `InvocationRow` (full row shape) plus `list_invocations(conn, filters)`
+that SELECTs with optional filters on ts >= ?, caller = ?, project = ?,
+parent_session = ?, ordered by ts ASC. Use `params_from_iter` for dynamic
+WHERE assembly. Keep `aggregate` untouched.
+
+### 3. CLI wiring
+
+- `src/main.rs`: new `Telemetry { action: TelemetryAction }` with
+  `TelemetryAction::ExportOtlp { since, caller, project, parent_session,
+  format }`.
+- `src/commands/mod.rs`: add `pub mod telemetry;`.
+
+### 4. Tests
+
+Unit tests in `src/commands/telemetry.rs`:
+
+- span_id_is_stable_and_hex
+- trace_id_groups_by_parent_session
+- trace_id_falls_back_on_orphan
+- status_reflects_is_error
+- attributes_include_gen_ai_and_rememora
+- name_maps_per_caller
+- end_time_uses_duration
+
+Model-level test:
+
+- list_invocations_filters_by_caller_and_project
+
+## Testing Strategy
+
+- cargo test — all tests green
+- cargo clippy --all-targets — no new warnings
+- cargo build --release — binary builds
+
+## Out of scope
+
+- Retention / auto-prune
+- OTLP gRPC
+- Remote collector push
+- Touching bench/ or A/B experiment harness

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -18,6 +18,7 @@ pub mod session;
 pub mod setup;
 pub mod status;
 pub mod supersede;
+pub mod telemetry;
 pub mod timeline;
 pub mod tui;
 pub mod usage;

--- a/src/commands/telemetry.rs
+++ b/src/commands/telemetry.rs
@@ -1,0 +1,568 @@
+//! `rememora telemetry export-otlp` — emit OTEL-compatible JSON spans from
+//! the existing `agent_invocations` table.
+//!
+//! Each row in `agent_invocations` becomes one OTLP span. Trace IDs are
+//! derived from `parent_session` so attempts that share a rememora session
+//! group into a single trace; span IDs are derived from the row ULID. The
+//! export is local-first and read-only — it never writes to the DB or pushes
+//! to a remote collector. Output goes to stdout.
+//!
+//! Two shapes are supported:
+//!   * `jsonl` (default) — one compact OTLP span JSON object per line.
+//!   * `otlp`            — a single OTLP HTTP/JSON document wrapping every
+//!                         span under `resourceSpans[0].scopeSpans[0]`.
+//!
+//! This verb intentionally re-parses `--since` locally rather than reaching
+//! into `commands::usage::parse_since`, so `usage.rs`'s surface stays stable.
+
+use anyhow::{bail, Context, Result};
+use chrono::{DateTime, Duration, Utc};
+use rusqlite::Connection;
+use serde_json::{json, Map, Value};
+
+use rememora::models::agent_invocation::{
+    self, InvocationFilter, InvocationRow,
+};
+
+pub struct TelemetryExportArgs {
+    pub since: String,
+    pub caller: Option<String>,
+    pub project: Option<String>,
+    pub parent_session: Option<String>,
+    pub format: String,
+}
+
+pub fn export_otlp(conn: &Connection, args: &TelemetryExportArgs) -> Result<()> {
+    let since = parse_since(&args.since).context("invalid --since value")?;
+    let format = parse_format(&args.format).context("invalid --format value")?;
+
+    let filter = InvocationFilter {
+        since,
+        caller: args.caller.clone(),
+        project: args.project.clone(),
+        parent_session: args.parent_session.clone(),
+    };
+
+    let rows = agent_invocation::list_invocations(conn, &filter)?;
+
+    match format {
+        OutputFormat::Jsonl => {
+            for row in &rows {
+                let span = row_to_span(row);
+                println!("{}", serde_json::to_string(&span)?);
+            }
+        }
+        OutputFormat::Otlp => {
+            let doc = spans_to_otlp_doc(&rows);
+            println!("{}", serde_json::to_string_pretty(&doc)?);
+        }
+    }
+
+    Ok(())
+}
+
+// ── Output format parsing ────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OutputFormat {
+    Jsonl,
+    Otlp,
+}
+
+fn parse_format(s: &str) -> Result<OutputFormat> {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "" | "jsonl" | "lines" | "otlp-jsonl" => Ok(OutputFormat::Jsonl),
+        "otlp" | "otlp-json" | "doc" => Ok(OutputFormat::Otlp),
+        other => bail!("unknown --format `{other}` (expected jsonl|otlp)"),
+    }
+}
+
+// ── Relative window parsing (mirrors commands::usage::parse_since) ───
+
+fn parse_since(s: &str) -> Result<Option<String>> {
+    let s = s.trim();
+    if s.eq_ignore_ascii_case("all") || s.is_empty() {
+        return Ok(None);
+    }
+
+    // Allow callers to pass a raw ISO8601 timestamp straight through.
+    if s.contains('T') && DateTime::parse_from_rfc3339(s).is_ok() {
+        return Ok(Some(s.to_string()));
+    }
+
+    let (n_str, unit) = s.split_at(
+        s.rfind(|c: char| c.is_ascii_digit())
+            .map(|i| i + 1)
+            .unwrap_or(0),
+    );
+    let n: i64 = n_str.parse().context("expected a number before the unit")?;
+    let duration = match unit.trim() {
+        "m" | "min" | "mins" => Duration::minutes(n),
+        "h" | "hr" | "hrs" => Duration::hours(n),
+        "d" | "day" | "days" => Duration::days(n),
+        "w" | "wk" | "wks" => Duration::weeks(n),
+        other => bail!("unknown time unit `{other}` (use m/h/d/w, `all`, or an ISO8601 timestamp)"),
+    };
+
+    let cutoff = Utc::now() - duration;
+    Ok(Some(cutoff.to_rfc3339()))
+}
+
+// ── Row → span mapping ───────────────────────────────────────────────
+
+/// Convert one `InvocationRow` into an OTLP-shaped JSON span.
+///
+/// The returned object is compatible with the OTLP/JSON schema for
+/// `opentelemetry.proto.trace.v1.Span`: hex `trace_id`/`span_id`,
+/// `start_time_unix_nano`/`end_time_unix_nano` as decimal strings (nanos
+/// overflow i32 but fit in i64; we stringify to match OTLP's convention for
+/// 64-bit fields), keyed `attributes` array with typed values, and a
+/// `status` object. Resource is emitted only in the doc-level `otlp` shape,
+/// not per-span in `jsonl` mode — callers that want a full document should
+/// use `--format otlp`.
+pub(crate) fn row_to_span(row: &InvocationRow) -> Value {
+    let trace_id = trace_id_hex(row);
+    let span_id = span_id_hex(&row.id);
+    let name = span_name_for(&row.caller);
+
+    let start_nano = rfc3339_to_unix_nano(&row.ts).unwrap_or(0);
+    let end_nano = match row.duration_ms {
+        Some(ms) if ms >= 0 => start_nano.saturating_add(ms as i128 * 1_000_000),
+        _ => start_nano,
+    };
+
+    let (status_code_int, status_code_str) = if row.is_error {
+        (2u32, "STATUS_CODE_ERROR")
+    } else {
+        (1u32, "STATUS_CODE_OK")
+    };
+
+    let attributes = build_attributes(row);
+
+    json!({
+        "traceId": trace_id,
+        "spanId": span_id,
+        "name": name,
+        "kind": 3, // SPAN_KIND_CLIENT — we are calling a remote LLM
+        "startTimeUnixNano": start_nano.to_string(),
+        "endTimeUnixNano": end_nano.to_string(),
+        "attributes": attributes,
+        "status": {
+            "code": status_code_int,
+            "codeName": status_code_str,
+        },
+    })
+}
+
+/// Wrap spans into a single OTLP HTTP/JSON document with one resourceSpans
+/// entry. Matches `opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest`.
+fn spans_to_otlp_doc(rows: &[InvocationRow]) -> Value {
+    let spans: Vec<Value> = rows.iter().map(row_to_span).collect();
+
+    json!({
+        "resourceSpans": [{
+            "resource": {
+                "attributes": [
+                    kv_string("service.name", "rememora"),
+                    kv_string("service.version", env!("CARGO_PKG_VERSION")),
+                ]
+            },
+            "scopeSpans": [{
+                "scope": {
+                    "name": "rememora",
+                    "version": env!("CARGO_PKG_VERSION"),
+                },
+                "spans": spans,
+            }]
+        }]
+    })
+}
+
+// ── Attribute builders ───────────────────────────────────────────────
+
+fn build_attributes(row: &InvocationRow) -> Vec<Value> {
+    let mut out: Vec<Value> = Vec::with_capacity(16);
+    out.push(kv_string("gen_ai.system", "anthropic"));
+    out.push(kv_string("gen_ai.request.model", &row.model));
+
+    if let Some(v) = row.input_tokens {
+        out.push(kv_int("gen_ai.usage.input_tokens", v));
+    }
+    if let Some(v) = row.output_tokens {
+        out.push(kv_int("gen_ai.usage.output_tokens", v));
+    }
+    if let Some(v) = row.cache_read_tokens {
+        out.push(kv_int("gen_ai.usage.cache_read_tokens", v));
+    }
+    if let Some(v) = row.cache_creation_tokens {
+        out.push(kv_int("gen_ai.usage.cache_creation_tokens", v));
+    }
+    if let Some(v) = row.cost_usd {
+        out.push(kv_double("gen_ai.response.cost_usd", v));
+    }
+    if let Some(v) = row.stop_reason.as_deref() {
+        out.push(kv_string("gen_ai.response.stop_reason", v));
+    }
+
+    out.push(kv_string("rememora.caller", &row.caller));
+    if let Some(v) = row.project.as_deref() {
+        out.push(kv_string("rememora.project", v));
+    }
+    if let Some(v) = row.parent_session.as_deref() {
+        out.push(kv_string("rememora.parent_session", v));
+    }
+    if let Some(v) = row.child_session.as_deref() {
+        out.push(kv_string("rememora.child_session", v));
+    }
+    if let Some(v) = row.terminal_reason.as_deref() {
+        out.push(kv_string("rememora.terminal_reason", v));
+    }
+    if let Some(v) = row.num_turns {
+        out.push(kv_int("rememora.num_turns", v));
+    }
+
+    out
+}
+
+fn kv_string(key: &str, val: &str) -> Value {
+    let mut m = Map::new();
+    m.insert("key".into(), Value::String(key.into()));
+    let mut inner = Map::new();
+    inner.insert("stringValue".into(), Value::String(val.into()));
+    m.insert("value".into(), Value::Object(inner));
+    Value::Object(m)
+}
+
+fn kv_int(key: &str, val: i64) -> Value {
+    let mut m = Map::new();
+    m.insert("key".into(), Value::String(key.into()));
+    let mut inner = Map::new();
+    // OTLP/JSON represents int64 as a decimal string to preserve precision.
+    inner.insert("intValue".into(), Value::String(val.to_string()));
+    m.insert("value".into(), Value::Object(inner));
+    Value::Object(m)
+}
+
+fn kv_double(key: &str, val: f64) -> Value {
+    let mut m = Map::new();
+    m.insert("key".into(), Value::String(key.into()));
+    let mut inner = Map::new();
+    inner.insert(
+        "doubleValue".into(),
+        serde_json::Number::from_f64(val)
+            .map(Value::Number)
+            .unwrap_or(Value::Null),
+    );
+    m.insert("value".into(), Value::Object(inner));
+    Value::Object(m)
+}
+
+// ── Name & id derivation ─────────────────────────────────────────────
+
+fn span_name_for(caller: &str) -> String {
+    match caller {
+        "signal_gate" => "rememora.signal_gate.run".to_string(),
+        "curator" => "rememora.curator.run".to_string(),
+        "extract" => "rememora.extract.run".to_string(),
+        "evolve" => "rememora.evolve.consolidate_cluster".to_string(),
+        "consolidate" => "rememora.consolidate.run".to_string(),
+        "agent_run" => "rememora.agent_run.attempt".to_string(),
+        other => format!("rememora.{other}.run"),
+    }
+}
+
+fn trace_id_hex(row: &InvocationRow) -> String {
+    // OTLP trace IDs are 16 bytes / 32 hex chars. Group attempts that share
+    // a parent session; fall back to the row id so orphaned rows still have
+    // a stable (per-span) trace id.
+    match row.parent_session.as_deref() {
+        Some(session) if !session.is_empty() => hash_hex_16(session.as_bytes(), b"trace"),
+        _ => hash_hex_16(row.id.as_bytes(), b"trace-orphan"),
+    }
+}
+
+fn span_id_hex(row_id: &str) -> String {
+    // OTLP span IDs are 8 bytes / 16 hex chars.
+    hash_hex_8(row_id.as_bytes(), b"span")
+}
+
+fn rfc3339_to_unix_nano(ts: &str) -> Option<i128> {
+    let parsed = DateTime::parse_from_rfc3339(ts).ok()?;
+    let secs = parsed.timestamp() as i128;
+    let subsec = parsed.timestamp_subsec_nanos() as i128;
+    Some(secs * 1_000_000_000 + subsec)
+}
+
+// ── Deterministic hashing (FNV-1a 64-bit) ────────────────────────────
+//
+// We avoid pulling in a crypto crate just to derive stable trace/span ids.
+// FNV-1a is trivial, deterministic across platforms, and more than enough
+// for the "attempts sharing a session should group" property — we are not
+// using this hash for security or for avoiding collisions across arbitrary
+// adversarial input.
+
+const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+const FNV_PRIME: u64 = 0x100_0000_01b3;
+
+fn fnv1a(data: &[u8]) -> u64 {
+    let mut h = FNV_OFFSET;
+    for &b in data {
+        h ^= b as u64;
+        h = h.wrapping_mul(FNV_PRIME);
+    }
+    h
+}
+
+fn hash_hex_16(data: &[u8], tag: &[u8]) -> String {
+    // 16 bytes of entropy: two independent FNV passes with distinct salts.
+    let a = fnv1a_with_salt(data, tag, 0);
+    let b = fnv1a_with_salt(data, tag, 1);
+    format!("{:016x}{:016x}", a, b)
+}
+
+fn hash_hex_8(data: &[u8], tag: &[u8]) -> String {
+    let a = fnv1a_with_salt(data, tag, 0);
+    format!("{:016x}", a)
+}
+
+fn fnv1a_with_salt(data: &[u8], tag: &[u8], round: u8) -> u64 {
+    let mut buf: Vec<u8> = Vec::with_capacity(data.len() + tag.len() + 2);
+    buf.extend_from_slice(tag);
+    buf.push(b':');
+    buf.push(round);
+    buf.extend_from_slice(data);
+    fnv1a(&buf)
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mk_row(id: &str, caller: &str) -> InvocationRow {
+        InvocationRow {
+            id: id.into(),
+            ts: "2026-04-21T12:00:00Z".into(),
+            caller: caller.into(),
+            model: "claude-sonnet".into(),
+            project: Some("demo".into()),
+            parent_session: Some("sess-1".into()),
+            child_session: Some("child-1".into()),
+            duration_ms: Some(1500),
+            duration_api_ms: Some(1400),
+            num_turns: Some(3),
+            input_tokens: Some(100),
+            output_tokens: Some(200),
+            cache_read_tokens: Some(50),
+            cache_creation_tokens: Some(25),
+            cost_usd: Some(0.0123),
+            stop_reason: Some("end_turn".into()),
+            terminal_reason: Some("ok".into()),
+            is_error: false,
+        }
+    }
+
+    #[test]
+    fn span_id_is_stable_and_hex() {
+        let row = mk_row("01ABC", "curator");
+        let span = row_to_span(&row);
+        let sid = span["spanId"].as_str().unwrap();
+        assert_eq!(sid.len(), 16);
+        assert!(sid.chars().all(|c| c.is_ascii_hexdigit()));
+        // Stability: re-hashing yields the same id.
+        let span2 = row_to_span(&row);
+        assert_eq!(span["spanId"], span2["spanId"]);
+    }
+
+    #[test]
+    fn trace_id_groups_by_parent_session() {
+        let mut a = mk_row("01A", "curator");
+        let mut b = mk_row("01B", "signal_gate");
+        a.parent_session = Some("shared-session".into());
+        b.parent_session = Some("shared-session".into());
+
+        let sa = row_to_span(&a);
+        let sb = row_to_span(&b);
+
+        assert_eq!(sa["traceId"], sb["traceId"]);
+        assert_ne!(sa["spanId"], sb["spanId"]);
+    }
+
+    #[test]
+    fn trace_id_falls_back_on_orphan() {
+        let mut a = mk_row("01A", "extract");
+        let mut b = mk_row("01B", "extract");
+        a.parent_session = None;
+        b.parent_session = None;
+
+        let sa = row_to_span(&a);
+        let sb = row_to_span(&b);
+
+        let ta = sa["traceId"].as_str().unwrap();
+        let tb = sb["traceId"].as_str().unwrap();
+        assert_eq!(ta.len(), 32);
+        assert_eq!(tb.len(), 32);
+        // Different orphans get different traces (derived from row id).
+        assert_ne!(ta, tb);
+        // Same row id stable.
+        let sa2 = row_to_span(&a);
+        assert_eq!(sa["traceId"], sa2["traceId"]);
+    }
+
+    #[test]
+    fn status_reflects_is_error() {
+        let mut row = mk_row("01ERR", "curator");
+        row.is_error = true;
+        let span = row_to_span(&row);
+        assert_eq!(span["status"]["code"], 2);
+        assert_eq!(span["status"]["codeName"], "STATUS_CODE_ERROR");
+
+        row.is_error = false;
+        let span = row_to_span(&row);
+        assert_eq!(span["status"]["code"], 1);
+        assert_eq!(span["status"]["codeName"], "STATUS_CODE_OK");
+    }
+
+    #[test]
+    fn attributes_include_gen_ai_and_rememora() {
+        let row = mk_row("01A", "curator");
+        let span = row_to_span(&row);
+        let attrs = span["attributes"].as_array().unwrap();
+
+        let keys: Vec<&str> = attrs
+            .iter()
+            .map(|a| a["key"].as_str().unwrap())
+            .collect();
+
+        for required in [
+            "gen_ai.system",
+            "gen_ai.request.model",
+            "gen_ai.usage.input_tokens",
+            "gen_ai.usage.output_tokens",
+            "gen_ai.usage.cache_read_tokens",
+            "gen_ai.usage.cache_creation_tokens",
+            "gen_ai.response.cost_usd",
+            "gen_ai.response.stop_reason",
+            "rememora.caller",
+            "rememora.project",
+            "rememora.parent_session",
+            "rememora.child_session",
+            "rememora.terminal_reason",
+            "rememora.num_turns",
+        ] {
+            assert!(
+                keys.contains(&required),
+                "missing attribute key: {required} in {keys:?}"
+            );
+        }
+
+        // gen_ai.system is always anthropic.
+        let system = attrs
+            .iter()
+            .find(|a| a["key"] == "gen_ai.system")
+            .unwrap();
+        assert_eq!(system["value"]["stringValue"], "anthropic");
+    }
+
+    #[test]
+    fn attributes_omit_null_fields() {
+        let mut row = mk_row("01A", "curator");
+        row.cost_usd = None;
+        row.stop_reason = None;
+        row.project = None;
+
+        let span = row_to_span(&row);
+        let keys: Vec<&str> = span["attributes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|a| a["key"].as_str().unwrap())
+            .collect();
+
+        assert!(!keys.contains(&"gen_ai.response.cost_usd"));
+        assert!(!keys.contains(&"gen_ai.response.stop_reason"));
+        assert!(!keys.contains(&"rememora.project"));
+    }
+
+    #[test]
+    fn name_maps_per_caller() {
+        let cases = [
+            ("signal_gate", "rememora.signal_gate.run"),
+            ("curator", "rememora.curator.run"),
+            ("extract", "rememora.extract.run"),
+            ("evolve", "rememora.evolve.consolidate_cluster"),
+            ("consolidate", "rememora.consolidate.run"),
+            ("agent_run", "rememora.agent_run.attempt"),
+            ("brand_new_kind", "rememora.brand_new_kind.run"),
+        ];
+        for (caller, expected) in cases {
+            let row = mk_row("01A", caller);
+            let span = row_to_span(&row);
+            assert_eq!(span["name"], expected, "caller {caller}");
+        }
+    }
+
+    #[test]
+    fn end_time_uses_duration() {
+        let mut row = mk_row("01A", "curator");
+        row.duration_ms = Some(2_000);
+        let span = row_to_span(&row);
+
+        let start: i128 = span["startTimeUnixNano"]
+            .as_str()
+            .unwrap()
+            .parse()
+            .unwrap();
+        let end: i128 = span["endTimeUnixNano"].as_str().unwrap().parse().unwrap();
+        assert_eq!(end - start, 2_000 * 1_000_000);
+
+        // No duration → end collapses to start.
+        row.duration_ms = None;
+        let span = row_to_span(&row);
+        assert_eq!(span["startTimeUnixNano"], span["endTimeUnixNano"]);
+    }
+
+    #[test]
+    fn otlp_doc_wraps_spans_with_resource() {
+        let row = mk_row("01A", "curator");
+        let doc = spans_to_otlp_doc(&[row]);
+        let rs = doc["resourceSpans"][0].clone();
+        let res_attrs = rs["resource"]["attributes"].as_array().unwrap();
+
+        let keys: Vec<&str> = res_attrs
+            .iter()
+            .map(|a| a["key"].as_str().unwrap())
+            .collect();
+        assert!(keys.contains(&"service.name"));
+        assert!(keys.contains(&"service.version"));
+
+        let spans = rs["scopeSpans"][0]["spans"].as_array().unwrap();
+        assert_eq!(spans.len(), 1);
+    }
+
+    #[test]
+    fn parse_since_accepts_all_and_windows() {
+        assert!(parse_since("all").unwrap().is_none());
+        assert!(parse_since("").unwrap().is_none());
+        assert!(parse_since("7d").unwrap().is_some());
+        assert!(parse_since("24h").unwrap().is_some());
+        assert!(parse_since("30m").unwrap().is_some());
+        assert!(parse_since("2w").unwrap().is_some());
+    }
+
+    #[test]
+    fn parse_since_accepts_rfc3339() {
+        let s = "2026-04-21T12:00:00+00:00";
+        assert_eq!(parse_since(s).unwrap().as_deref(), Some(s));
+    }
+
+    #[test]
+    fn parse_format_aliases() {
+        assert_eq!(parse_format("").unwrap(), OutputFormat::Jsonl);
+        assert_eq!(parse_format("jsonl").unwrap(), OutputFormat::Jsonl);
+        assert_eq!(parse_format("otlp").unwrap(), OutputFormat::Otlp);
+        assert_eq!(parse_format("OTLP").unwrap(), OutputFormat::Otlp);
+        assert!(parse_format("yaml").is_err());
+    }
+}

--- a/src/commands/telemetry.rs
+++ b/src/commands/telemetry.rs
@@ -9,8 +9,8 @@
 //!
 //! Two shapes are supported:
 //!   * `jsonl` (default) — one compact OTLP span JSON object per line.
-//!   * `otlp`            — a single OTLP HTTP/JSON document wrapping every
-//!                         span under `resourceSpans[0].scopeSpans[0]`.
+//!   * `otlp` — a single OTLP HTTP/JSON document wrapping every span under
+//!     `resourceSpans[0].scopeSpans[0]`.
 //!
 //! This verb intentionally re-parses `--since` locally rather than reaching
 //! into `commands::usage::parse_since`, so `usage.rs`'s surface stays stable.

--- a/src/main.rs
+++ b/src/main.rs
@@ -402,6 +402,45 @@ enum Commands {
 
     /// Launch the Rememora Desktop app (Tauri)
     Desktop,
+
+    /// Local-first telemetry export (OTEL / OTLP).
+    Telemetry {
+        #[command(subcommand)]
+        action: TelemetryAction,
+    },
+}
+
+#[derive(Subcommand)]
+enum TelemetryAction {
+    /// Emit OTEL-compatible JSON spans from `agent_invocations` to stdout.
+    ///
+    /// One row becomes one span. Trace IDs group attempts sharing a
+    /// rememora session; span IDs are derived from the row ULID. The
+    /// default format is JSON Lines (one span per line) so the output can
+    /// be piped into `jq`, `tee`, or an OTLP JSON-file importer. Passing
+    /// `--format otlp` emits a single OTLP HTTP/JSON document instead.
+    ExportOtlp {
+        /// Time range: `7d`, `24h`, `30m`, `all`, or an ISO8601 timestamp.
+        #[arg(long, default_value = "all")]
+        since: String,
+
+        /// Only export this caller (e.g. agent_run, curator, signal_gate).
+        #[arg(long)]
+        caller: Option<String>,
+
+        /// Only export rows for this project.
+        #[arg(long)]
+        project: Option<String>,
+
+        /// Only export rows with this exact parent_session id.
+        #[arg(long)]
+        parent_session: Option<String>,
+
+        /// Output format: `jsonl` (default, one span per line) or `otlp`
+        /// (single OTLP HTTP/JSON document).
+        #[arg(long, default_value = "jsonl")]
+        format: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -837,5 +876,24 @@ fn main() -> Result<()> {
             &commands::usage::UsageArgs { since, by },
             cli.json,
         ),
+
+        Commands::Telemetry { action } => match action {
+            TelemetryAction::ExportOtlp {
+                since,
+                caller,
+                project,
+                parent_session,
+                format,
+            } => commands::telemetry::export_otlp(
+                &conn,
+                &commands::telemetry::TelemetryExportArgs {
+                    since,
+                    caller,
+                    project,
+                    parent_session,
+                    format,
+                },
+            ),
+        },
     }
 }

--- a/src/models/agent_invocation.rs
+++ b/src/models/agent_invocation.rs
@@ -9,7 +9,7 @@
 //! Readers are `rememora usage` (aggregation) and the TUI cost tile.
 
 use anyhow::Result;
-use rusqlite::{params, Connection};
+use rusqlite::{params, params_from_iter, types::Value as SqlValue, Connection};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -266,6 +266,112 @@ pub fn aggregate(
     Ok(rows)
 }
 
+// ── Row listing (for telemetry export) ──────────────────────────────
+
+/// Full row shape for `agent_invocations`. Mirrors the table columns plus
+/// the row id. Used by the OTEL export layer which needs the raw per-row
+/// data rather than grouped aggregates.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InvocationRow {
+    pub id: String,
+    pub ts: String,
+    pub caller: String,
+    pub model: String,
+    pub project: Option<String>,
+    pub parent_session: Option<String>,
+    pub child_session: Option<String>,
+    pub duration_ms: Option<i64>,
+    pub duration_api_ms: Option<i64>,
+    pub num_turns: Option<i64>,
+    pub input_tokens: Option<i64>,
+    pub output_tokens: Option<i64>,
+    pub cache_read_tokens: Option<i64>,
+    pub cache_creation_tokens: Option<i64>,
+    pub cost_usd: Option<f64>,
+    pub stop_reason: Option<String>,
+    pub terminal_reason: Option<String>,
+    pub is_error: bool,
+}
+
+/// Optional filters for `list_invocations`. `None` means "no predicate on
+/// this column". `since` is an ISO8601/RFC3339 string (inclusive).
+#[derive(Debug, Clone, Default)]
+pub struct InvocationFilter {
+    pub since: Option<String>,
+    pub caller: Option<String>,
+    pub project: Option<String>,
+    pub parent_session: Option<String>,
+}
+
+/// List raw invocation rows, ordered ts ASC, matching every non-None filter.
+pub fn list_invocations(
+    conn: &Connection,
+    filter: &InvocationFilter,
+) -> Result<Vec<InvocationRow>> {
+    let mut clauses: Vec<&'static str> = Vec::new();
+    let mut args: Vec<SqlValue> = Vec::new();
+
+    if let Some(ts) = filter.since.as_deref() {
+        clauses.push("ts >= ?");
+        args.push(SqlValue::Text(ts.to_string()));
+    }
+    if let Some(c) = filter.caller.as_deref() {
+        clauses.push("caller = ?");
+        args.push(SqlValue::Text(c.to_string()));
+    }
+    if let Some(p) = filter.project.as_deref() {
+        clauses.push("project = ?");
+        args.push(SqlValue::Text(p.to_string()));
+    }
+    if let Some(s) = filter.parent_session.as_deref() {
+        clauses.push("parent_session = ?");
+        args.push(SqlValue::Text(s.to_string()));
+    }
+
+    let where_sql = if clauses.is_empty() {
+        String::new()
+    } else {
+        format!(" WHERE {}", clauses.join(" AND "))
+    };
+
+    let sql = format!(
+        "SELECT id, ts, caller, model, project, parent_session, child_session,
+                duration_ms, duration_api_ms, num_turns,
+                input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
+                cost_usd, stop_reason, terminal_reason, is_error
+         FROM agent_invocations{where_sql}
+         ORDER BY ts ASC"
+    );
+
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt
+        .query_map(params_from_iter(args.iter()), |row| {
+            Ok(InvocationRow {
+                id: row.get(0)?,
+                ts: row.get(1)?,
+                caller: row.get(2)?,
+                model: row.get(3)?,
+                project: row.get(4)?,
+                parent_session: row.get(5)?,
+                child_session: row.get(6)?,
+                duration_ms: row.get(7)?,
+                duration_api_ms: row.get(8)?,
+                num_turns: row.get(9)?,
+                input_tokens: row.get(10)?,
+                output_tokens: row.get(11)?,
+                cache_read_tokens: row.get(12)?,
+                cache_creation_tokens: row.get(13)?,
+                cost_usd: row.get(14)?,
+                stop_reason: row.get(15)?,
+                terminal_reason: row.get(16)?,
+                is_error: row.get::<_, i64>(17)? != 0,
+            })
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+
+    Ok(rows)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -351,6 +457,77 @@ mod tests {
         let recent = aggregate(&conn, Some("2020-01-01T00:00:00Z"), GroupBy::Total).unwrap();
         assert_eq!(recent[0].invocations, 1);
         assert!((recent[0].cost_usd - 0.20).abs() < 1e-9);
+    }
+
+    #[test]
+    fn list_invocations_filters_by_caller_project_and_session() {
+        let conn = db::open_memory().unwrap();
+
+        let mut a = sample(Caller::Curator, "sonnet", 0.10);
+        a.project = Some("alpha".into());
+        a.parent_session = Some("s-1".into());
+        insert(&conn, &a).unwrap();
+
+        let mut b = sample(Caller::SignalGate, "haiku", 0.02);
+        b.project = Some("beta".into());
+        b.parent_session = Some("s-1".into());
+        insert(&conn, &b).unwrap();
+
+        let mut c = sample(Caller::Extract, "sonnet", 0.05);
+        c.project = Some("alpha".into());
+        c.parent_session = Some("s-2".into());
+        insert(&conn, &c).unwrap();
+
+        // All rows.
+        let all = list_invocations(&conn, &InvocationFilter::default()).unwrap();
+        assert_eq!(all.len(), 3);
+
+        // Caller filter.
+        let curators = list_invocations(
+            &conn,
+            &InvocationFilter {
+                caller: Some("curator".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(curators.len(), 1);
+        assert_eq!(curators[0].caller, "curator");
+
+        // Project filter.
+        let alpha = list_invocations(
+            &conn,
+            &InvocationFilter {
+                project: Some("alpha".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(alpha.len(), 2);
+
+        // Parent-session filter.
+        let s1 = list_invocations(
+            &conn,
+            &InvocationFilter {
+                parent_session: Some("s-1".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(s1.len(), 2);
+
+        // Combined filter.
+        let combo = list_invocations(
+            &conn,
+            &InvocationFilter {
+                project: Some("alpha".into()),
+                parent_session: Some("s-1".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(combo.len(), 1);
+        assert_eq!(combo[0].caller, "curator");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds `rememora telemetry export-otlp` — a read-only, local-first export verb that renders each `agent_invocations` row as an OTEL-compatible JSON span. Closes #76.

- Keeps `agent_invocations` as the single source of truth (no parallel spans table); `rememora usage` continues to aggregate from the same table. OTEL becomes a view/interop concern.
- `trace_id` groups attempts sharing a `parent_session`; `span_id` is derived from the row ULID. Ids are stable across runs via a small FNV-1a hash with per-role salts — no crypto dep added.
- Caller-specific span names: `rememora.curator.run`, `rememora.signal_gate.run`, `rememora.extract.run`, `rememora.evolve.consolidate_cluster`, `rememora.consolidate.run`, `rememora.agent_run.attempt`. Unknown callers fall back to `rememora.<caller>.run`.
- Attributes follow the OTEL `gen_ai.*` convention (`gen_ai.system=anthropic`, `gen_ai.request.model`, `gen_ai.usage.{input,output,cache_read,cache_creation}_tokens`, `gen_ai.response.{cost_usd,stop_reason}`) plus a `rememora.*` namespace for `caller`, `project`, `parent_session`, `child_session`, `terminal_reason`, `num_turns`. Null columns are omitted.
- Two output shapes, stdout only:
  - `--format jsonl` (default) — one compact OTLP span JSON per line.
  - `--format otlp` — single OTLP HTTP/JSON document with `resourceSpans[0]` carrying `service.name=rememora`, `service.version=CARGO_PKG_VERSION`.
- Filters mirror `rememora usage`: `--since` (`7d` / `24h` / `30m` / `all` / ISO8601), `--caller`, `--project`, `--parent-session`.

Out of scope (explicit): retention / auto-prune, OTLP gRPC, remote collector push.

### Sample output

Run against the local dev DB (`--since 7d`, 1205 spans).

One span as `--format jsonl` (default):

```json
{"attributes":[{"key":"gen_ai.system","value":{"stringValue":"anthropic"}},{"key":"gen_ai.request.model","value":{"stringValue":"claude-haiku-4-5-20251001"}},{"key":"gen_ai.usage.input_tokens","value":{"intValue":"9"}},{"key":"gen_ai.usage.output_tokens","value":{"intValue":"534"}},{"key":"gen_ai.usage.cache_read_tokens","value":{"intValue":"0"}},{"key":"gen_ai.usage.cache_creation_tokens","value":{"intValue":"28998"}},{"key":"gen_ai.response.cost_usd","value":{"doubleValue":0.0389265}},{"key":"gen_ai.response.stop_reason","value":{"stringValue":"end_turn"}},{"key":"rememora.caller","value":{"stringValue":"signal_gate"}},{"key":"rememora.project","value":{"stringValue":"renotes"}},{"key":"rememora.child_session","value":{"stringValue":"e9b929cb-694b-4919-9544-b2fef0ff2615"}},{"key":"rememora.terminal_reason","value":{"stringValue":"completed"}},{"key":"rememora.num_turns","value":{"intValue":"1"}}],"endTimeUnixNano":"1776556432698975000","kind":3,"name":"rememora.signal_gate.run","spanId":"2ec1791d9a69bde8","startTimeUnixNano":"1776556424121975000","status":{"code":1,"codeName":"STATUS_CODE_OK"},"traceId":"e039d4dbbd03066e59f8b47ac7aa3f4d"}
```

Truncated `--format otlp` doc (resource block + first span; trailing spans elided):

```json
{
  "resourceSpans": [
    {
      "resource": {
        "attributes": [
          { "key": "service.name",    "value": { "stringValue": "rememora" } },
          { "key": "service.version", "value": { "stringValue": "1.2.1"    } }
        ]
      },
      "scopeSpans": [
        {
          "scope": { "name": "rememora", "version": "1.2.1" },
          "spans": [
            {
              "attributes": [
                { "key": "gen_ai.system",                    "value": { "stringValue": "anthropic" } },
                { "key": "gen_ai.request.model",             "value": { "stringValue": "claude-haiku-4-5-20251001" } },
                { "key": "gen_ai.usage.input_tokens",        "value": { "intValue":    "9" } },
                { "key": "gen_ai.usage.output_tokens",       "value": { "intValue":    "534" } },
                { "key": "gen_ai.usage.cache_read_tokens",   "value": { "intValue":    "0" } },
                { "key": "gen_ai.usage.cache_creation_tokens","value": { "intValue":   "28998" } },
                { "key": "gen_ai.response.cost_usd",         "value": { "doubleValue": 0.0389265 } },
                { "key": "gen_ai.response.stop_reason",      "value": { "stringValue": "end_turn" } },
                { "key": "rememora.caller",                  "value": { "stringValue": "signal_gate" } },
                { "key": "rememora.project",                 "value": { "stringValue": "renotes" } },
                { "key": "rememora.child_session",           "value": { "stringValue": "e9b929cb-694b-4919-9544-b2fef0ff2615" } },
                { "key": "rememora.terminal_reason",         "value": { "stringValue": "completed" } },
                { "key": "rememora.num_turns",               "value": { "intValue":    "1" } }
              ],
              "endTimeUnixNano":   "1776556432698975000",
              "kind": 3,
              "name": "rememora.signal_gate.run",
              "spanId":  "2ec1791d9a69bde8",
              "startTimeUnixNano": "1776556424121975000",
              "status": { "code": 1, "codeName": "STATUS_CODE_OK" },
              "traceId": "e039d4dbbd03066e59f8b47ac7aa3f4d"
            }
          ]
        }
      ]
    }
  ]
}
```

(`spans` array elided here for brevity — actual run emitted 1205 entries.)

## Test plan

- [x] `cargo test` — all 63+27+… tests green, including the new mapping and filter tests.
- [x] `cargo clippy --all-targets` — no new warnings on the added files.
- [x] `cargo build --release` — binary builds.
- [x] Smoke: `rememora telemetry export-otlp --since all` emits one JSON span per row against the dev DB; shape validated.
- [x] Smoke: `rememora telemetry export-otlp --since 24h --format otlp` emits a single OTLP document with `resourceSpans[0].resource.attributes` carrying `service.name=rememora` and `service.version=1.2.1`.
- [x] Row → span mapping unit tests: `span_id_is_stable_and_hex`, `trace_id_groups_by_parent_session`, `trace_id_falls_back_on_orphan`, `status_reflects_is_error`, `attributes_include_gen_ai_and_rememora`, `attributes_omit_null_fields`, `name_maps_per_caller`, `end_time_uses_duration`, `otlp_doc_wraps_spans_with_resource`.
- [x] Reader filter tests: `list_invocations_filters_by_caller_project_and_session` (caller / project / parent_session / combined).

## Plan

See `.agents/plans/76-otel-export.md`.
