### PR TITLE
feat(observability): hook gate-outcome metrics for recursion gates (#82)

### DIFF
--- a/PLAN-82.md
+++ b/PLAN-82.md
@@ -1,0 +1,101 @@
+# Plan: Observability for curate recursion gates (#82)
+
+**Ticket:** https://github.com/Rememora/rememora/issues/82
+
+## Summary
+
+Two recursion gates currently guard `rememora curate` against stampedes/recursion:
+
+1. The `REMEMORA_CURATE_CHILD=1` env var (set in `curator::build_subagent_command`) — short-circuits the Stop hook in curate-spawned children.
+2. The `pgrep` gate in `plugin/scripts/stop-curate.sh` — prevents concurrent curate per session at the kernel level.
+
+We have no production telemetry on how often each gate fires vs. passes through. Before we propose a third (DB-backed, session-aware) gate, we need to *measure* the existing two. This change adds **observability only** — no new gate.
+
+Approach:
+
+- Add a new `hook_invocations` table (migration 005) — small, dedicated, separate from `agent_invocations` (which carries token/cost columns that are meaningless for hook events).
+- Expose a private CLI verb `rememora debug record-hook-event` that the shell hook calls at each gate exit. One row per Stop-hook invocation.
+- Surface the data via `rememora usage --hooks` (mirrors existing usage filters).
+- The shell must never block on telemetry — emission failures are silently swallowed and curate proceeds.
+
+## Implementation Steps
+
+### 1. New migration — `src/migrations/005_hook_invocations.sql`
+
+```sql
+CREATE TABLE IF NOT EXISTS hook_invocations (
+    id              TEXT PRIMARY KEY,
+    ts              TEXT NOT NULL,
+    hook            TEXT NOT NULL,
+    outcome         TEXT NOT NULL,
+    session_id      TEXT,
+    parent_session  TEXT,
+    cooldown_state  TEXT,
+    extra           TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_hook_invocations_ts        ON hook_invocations(ts DESC);
+CREATE INDEX IF NOT EXISTS idx_hook_invocations_hook_ts   ON hook_invocations(hook, ts DESC);
+CREATE INDEX IF NOT EXISTS idx_hook_invocations_outcome   ON hook_invocations(outcome);
+CREATE INDEX IF NOT EXISTS idx_hook_invocations_session   ON hook_invocations(session_id);
+```
+
+Wire in `src/db.rs` following the existing `MIGRATION_004` pattern.
+
+### 2. New model — `src/models/hook_invocation.rs`
+
+Mirror `agent_invocation.rs` shape but smaller. Provide:
+
+- `enum HookKind { StopCurate }` with `as_str()` and `from_str()`.
+- `enum Outcome { EnvVarShortCircuit, PgrepShortCircuit, CooldownShortCircuit, PassedThrough }` with `as_str()` and `from_str()`.
+- `struct HookEventRecord { hook, outcome, session_id, parent_session, cooldown_state, extra }`.
+- `pub fn insert(conn, record) -> Result<String>` — generates ULID + ts.
+- `pub fn try_insert(conn, record)` — best-effort.
+- `struct HookAggregate { hook, outcome, count }` and `pub fn aggregate_by_outcome(conn, since, hook_filter)`.
+
+Register in `src/models/mod.rs`.
+
+### 3. New private command — `src/commands/debug_hook.rs`
+
+Tiny handler that validates inputs against the enums and inserts one row.
+
+### 4. New CLI subcommand `Debug` in `src/main.rs`
+
+Add `Debug` with nested action `RecordHookEvent`. Help text marks it experimental.
+
+### 5. Extend `rememora usage` with `--hooks`
+
+Per the issue, prefer `--hooks` over a sibling verb. When set, `usage::run` calls the hook aggregator and prints a hook-shaped table. JSON mode mirrors structure. Since-filter reuses `parse_since`.
+
+### 6. Modify `plugin/scripts/stop-curate.sh`
+
+Add `_emit` helper that backgrounds the call so the hook returns instantly and redirects all streams. Insertion points:
+
+- env-var gate (early exit) → `env_var_short_circuit` (no session_id at that point).
+- pgrep gate → `pgrep_short_circuit`.
+- cooldown gate → `cooldown_short_circuit`.
+- just before fork → `passed_through`.
+
+Kill-switch (`REMEMORA_DISABLE_HOOKS`) is NOT instrumented — it is user config, not a recursion gate.
+
+### 7. Tests
+
+- Rust unit tests in `models/hook_invocation.rs`, `commands/debug_hook.rs`, `commands/usage.rs`.
+- Integration test `tests/test_hook_invocations.rs` exercising the `record` path.
+- Shell smoke test invoking `stop-curate.sh` against a scratch DB.
+
+## Testing Strategy
+
+```bash
+cargo test
+cargo clippy -- -D warnings
+REMEMORA_DB=/tmp/rememora-smoke.db \
+  rememora debug record-hook-event --hook stop-curate --outcome passed_through --session-id smoke-1
+REMEMORA_DB=/tmp/rememora-smoke.db rememora usage --hooks --since all
+```
+
+## Out of Scope
+
+- New gates (DB-backed session-aware).
+- OTLP export of hook events.
+- Backfill of historical data.
+- Reusing `agent_invocations`.

--- a/plugin/scripts/stop-curate.sh
+++ b/plugin/scripts/stop-curate.sh
@@ -1,11 +1,32 @@
 #!/usr/bin/env bash
+# Telemetry helper for recursion-gate observability (#82). Always backgrounded
+# and stream-redirected so a stuck DB or missing binary cannot block Claude
+# Code. Returns 0 unconditionally — the hook MUST never fail on telemetry.
+_emit() {
+  local outcome="$1"
+  local cooldown_state="${2:-unknown}"
+  local sid="${SESSION_ID:-}"
+  command -v rememora >/dev/null 2>&1 || return 0
+  (rememora debug record-hook-event \
+      --hook stop-curate \
+      --outcome "$outcome" \
+      ${sid:+--session-id "$sid"} \
+      --cooldown-state "$cooldown_state" \
+      </dev/null >/dev/null 2>&1 &) || true
+  return 0
+}
+
 # Do not curate our own children. `rememora curate` spawns `claude -p`
 # subprocesses for signal detection / AUDN curation; each child gets its own
 # session_id and fires its own Stop hook. Without this gate, curate recursively
 # curates itself.
-[ -n "${REMEMORA_CURATE_CHILD:-}" ] && exit 0
+if [ -n "${REMEMORA_CURATE_CHILD:-}" ]; then
+  _emit env_var_short_circuit unknown
+  exit 0
+fi
 
 # Kill-switch: set REMEMORA_DISABLE_HOOKS=1 to disable all Rememora hooks.
+# Not instrumented — kill-switch is user config, not a recursion gate.
 [ -n "${REMEMORA_DISABLE_HOOKS:-}" ] && exit 0
 
 # Rememora Stop hook — curates memories from the current session transcript.
@@ -54,22 +75,36 @@ PROJECT=$(basename "$CWD")
 #    says (not start-to-start).
 #
 # Set REMEMORA_CURATE_COOLDOWN_SECS=0 to disable the frequency gate.
-if pgrep -f "rememora curate --file .*${SESSION_ID}" >/dev/null 2>&1; then
-  exit 0
-fi
-
 COOLDOWN="${REMEMORA_CURATE_COOLDOWN_SECS:-300}"
 LOCK_DIR="${TMPDIR:-/tmp}"
 STAMP="${LOCK_DIR%/}/rememora-curate-${SESSION_ID}.last"
 
+# Compute cooldown_state up front so every emit point can reference it.
+# fresh         → no stamp file yet
+# within_window → stamp exists and is younger than COOLDOWN
+# expired       → stamp exists and is older than COOLDOWN
+COOLDOWN_STATE=fresh
 if [ -f "$STAMP" ]; then
-  # Portable mtime: BSD stat (macOS) first, GNU stat (Linux) fallback.
   LAST=$(stat -f %m "$STAMP" 2>/dev/null || stat -c %Y "$STAMP" 2>/dev/null || echo 0)
   NOW=$(date +%s)
   if [ $((NOW - LAST)) -lt "$COOLDOWN" ]; then
-    exit 0
+    COOLDOWN_STATE=within_window
+  else
+    COOLDOWN_STATE=expired
   fi
 fi
+
+if pgrep -f "rememora curate --file .*${SESSION_ID}" >/dev/null 2>&1; then
+  _emit pgrep_short_circuit "$COOLDOWN_STATE"
+  exit 0
+fi
+
+if [ "$COOLDOWN_STATE" = "within_window" ]; then
+  _emit cooldown_short_circuit within_window
+  exit 0
+fi
+
+_emit passed_through "$COOLDOWN_STATE"
 
 # Fork curation to a fully detached background process.
 #

--- a/src/commands/debug_hook.rs
+++ b/src/commands/debug_hook.rs
@@ -1,0 +1,137 @@
+//! `rememora debug record-hook-event` — record a single hook gate-outcome
+//! event into `hook_invocations`.
+//!
+//! Called from `plugin/scripts/stop-curate.sh` at each gate-exit point.
+//! The verb is intentionally private/experimental: the schema may churn
+//! during the validation window for issue #82.
+//!
+//! Resilience contract: this command must never fail in a way that the
+//! shell hook would surface to the user. We validate inputs against known
+//! enums (so a typo produces a sensible CLI error during development) but
+//! the actual insert uses `try_insert` — a missing/locked DB will not
+//! propagate.
+
+use anyhow::Result;
+use rusqlite::Connection;
+
+use rememora::models::hook_invocation::{self, HookEventRecord, HookKind, Outcome};
+
+#[derive(Debug, Clone)]
+pub struct RecordHookEventArgs {
+    pub hook: String,
+    pub outcome: String,
+    pub session_id: Option<String>,
+    pub parent_session: Option<String>,
+    pub cooldown_state: Option<String>,
+    pub extra: Option<String>,
+}
+
+pub fn record(conn: &Connection, args: &RecordHookEventArgs) -> Result<()> {
+    let hook = HookKind::parse(&args.hook)?;
+    let outcome = Outcome::parse(&args.outcome)?;
+
+    let record = HookEventRecord {
+        hook: hook.as_str(),
+        outcome: outcome.as_str(),
+        session_id: args.session_id.clone().filter(|s| !s.is_empty()),
+        parent_session: args.parent_session.clone().filter(|s| !s.is_empty()),
+        cooldown_state: args.cooldown_state.clone().filter(|s| !s.is_empty()),
+        extra: args.extra.clone().filter(|s| !s.is_empty()),
+    };
+
+    hook_invocation::try_insert(conn, &record);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rememora::db;
+
+    #[test]
+    fn record_writes_a_row() {
+        let conn = db::open_memory().unwrap();
+        record(
+            &conn,
+            &RecordHookEventArgs {
+                hook: "stop-curate".into(),
+                outcome: "passed_through".into(),
+                session_id: Some("abc".into()),
+                parent_session: None,
+                cooldown_state: Some("fresh".into()),
+                extra: None,
+            },
+        )
+        .unwrap();
+
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM hook_invocations", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn record_rejects_unknown_outcome() {
+        let conn = db::open_memory().unwrap();
+        let err = record(
+            &conn,
+            &RecordHookEventArgs {
+                hook: "stop-curate".into(),
+                outcome: "bogus".into(),
+                session_id: None,
+                parent_session: None,
+                cooldown_state: None,
+                extra: None,
+            },
+        )
+        .unwrap_err();
+        assert!(format!("{err}").contains("unknown outcome"));
+    }
+
+    #[test]
+    fn record_rejects_unknown_hook() {
+        let conn = db::open_memory().unwrap();
+        let err = record(
+            &conn,
+            &RecordHookEventArgs {
+                hook: "nope".into(),
+                outcome: "passed_through".into(),
+                session_id: None,
+                parent_session: None,
+                cooldown_state: None,
+                extra: None,
+            },
+        )
+        .unwrap_err();
+        assert!(format!("{err}").contains("unknown hook"));
+    }
+
+    #[test]
+    fn empty_strings_become_null() {
+        let conn = db::open_memory().unwrap();
+        record(
+            &conn,
+            &RecordHookEventArgs {
+                hook: "stop-curate".into(),
+                outcome: "env_var_short_circuit".into(),
+                session_id: Some("".into()),
+                parent_session: Some("".into()),
+                cooldown_state: Some("".into()),
+                extra: None,
+            },
+        )
+        .unwrap();
+
+        let nulls: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM hook_invocations
+                 WHERE session_id IS NULL
+                   AND parent_session IS NULL
+                   AND cooldown_state IS NULL",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(nulls, 1);
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod agent_run;
 pub mod consolidate;
 pub mod context;
 pub mod curate;
+pub mod debug_hook;
 pub mod desktop;
 pub mod encrypt;
 pub mod eval;

--- a/src/commands/usage.rs
+++ b/src/commands/usage.rs
@@ -10,16 +10,23 @@ use chrono::{Duration, Utc};
 use rusqlite::Connection;
 
 use rememora::models::agent_invocation::{self, GroupBy, UsageAggregate};
+use rememora::models::hook_invocation::{self, HookAggregate};
 
 pub struct UsageArgs {
     pub since: String,
     pub by: String,
+    pub hooks: bool,
+    pub hook: Option<String>,
 }
 
 pub fn run(conn: &Connection, args: &UsageArgs, json_output: bool) -> Result<()> {
     let since = parse_since(&args.since).context("invalid --since value")?;
-    let group_by = parse_group_by(&args.by).context("invalid --by value")?;
 
+    if args.hooks {
+        return run_hooks(conn, args, since.as_deref(), json_output);
+    }
+
+    let group_by = parse_group_by(&args.by).context("invalid --by value")?;
     let rows = agent_invocation::aggregate(conn, since.as_deref(), group_by)?;
 
     if json_output {
@@ -31,6 +38,28 @@ pub fn run(conn: &Connection, args: &UsageArgs, json_output: bool) -> Result<()>
         println!("{}", serde_json::to_string_pretty(&out)?);
     } else {
         print_table(&args.by, &args.since, &rows);
+    }
+
+    Ok(())
+}
+
+fn run_hooks(
+    conn: &Connection,
+    args: &UsageArgs,
+    since: Option<&str>,
+    json_output: bool,
+) -> Result<()> {
+    let rows = hook_invocation::aggregate_by_outcome(conn, since, args.hook.as_deref())?;
+
+    if json_output {
+        let out = serde_json::json!({
+            "since": args.since,
+            "hook": args.hook,
+            "rows": rows,
+        });
+        println!("{}", serde_json::to_string_pretty(&out)?);
+    } else {
+        print_hooks_table(&args.since, &rows);
     }
 
     Ok(())
@@ -138,6 +167,36 @@ fn print_table(by: &str, since: &str, rows: &[UsageAggregate]) {
     }
 }
 
+fn print_hooks_table(since: &str, rows: &[HookAggregate]) {
+    if rows.is_empty() {
+        if since.trim().eq_ignore_ascii_case("all") || since.trim().is_empty() {
+            println!("No hook invocations recorded.");
+        } else {
+            println!("No hook invocations recorded in this window.");
+        }
+        return;
+    }
+
+    println!("{:<16} {:<28} {:>8}", "hook", "outcome", "calls");
+    println!("{}", "-".repeat(56));
+
+    let mut total = 0i64;
+    for row in rows {
+        total += row.count;
+        println!(
+            "{:<16} {:<28} {:>8}",
+            truncate(&row.hook, 16),
+            truncate(&row.outcome, 28),
+            row.count,
+        );
+    }
+
+    if rows.len() > 1 {
+        println!("{}", "-".repeat(56));
+        println!("{:<16} {:<28} {:>8}", "TOTAL", "", total);
+    }
+}
+
 fn truncate(s: &str, max: usize) -> String {
     if s.chars().count() <= max {
         s.to_string()
@@ -179,5 +238,33 @@ mod tests {
         assert_eq!(parse_group_by("session").unwrap(), GroupBy::ParentSession);
         assert_eq!(parse_group_by("total").unwrap(), GroupBy::Total);
         assert!(parse_group_by("weird").is_err());
+    }
+
+    #[test]
+    fn hooks_branch_aggregates_by_outcome() {
+        use rememora::db;
+        use rememora::models::hook_invocation::{self, HookEventRecord};
+
+        let conn = db::open_memory().unwrap();
+        for outcome in ["passed_through", "passed_through", "pgrep_short_circuit"] {
+            hook_invocation::insert(
+                &conn,
+                &HookEventRecord {
+                    hook: "stop-curate",
+                    outcome,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        }
+
+        let args = UsageArgs {
+            since: "all".into(),
+            by: "caller".into(),
+            hooks: true,
+            hook: None,
+        };
+        // Smoke: must not panic and must return Ok.
+        run(&conn, &args, true).unwrap();
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -6,6 +6,7 @@ const MIGRATION_001: &str = include_str!("migrations/001_initial.sql");
 const MIGRATION_002: &str = include_str!("migrations/002_embeddings.sql");
 const MIGRATION_003: &str = include_str!("migrations/003_curator.sql");
 const MIGRATION_004: &str = include_str!("migrations/004_agent_invocations.sql");
+const MIGRATION_005: &str = include_str!("migrations/005_hook_invocations.sql");
 
 /// Register sqlite-vec extension before opening connections.
 /// Must be called before any Connection::open calls.
@@ -133,6 +134,20 @@ fn migrate(conn: &Connection) -> Result<()> {
         conn.execute_batch(MIGRATION_004)?;
         conn.execute(
             "INSERT INTO _migrations (name, applied_at) VALUES ('004_agent_invocations', datetime('now'))",
+            [],
+        )?;
+    }
+
+    let applied_005: bool = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM _migrations WHERE name = '005_hook_invocations')",
+        [],
+        |row| row.get(0),
+    )?;
+
+    if !applied_005 {
+        conn.execute_batch(MIGRATION_005)?;
+        conn.execute(
+            "INSERT INTO _migrations (name, applied_at) VALUES ('005_hook_invocations', datetime('now'))",
             [],
         )?;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -398,6 +398,22 @@ enum Commands {
         /// How to group: `total`, `caller`, `model`, `project`, `session`.
         #[arg(long, default_value = "caller")]
         by: String,
+
+        /// Aggregate plugin hook invocations (recursion-gate outcomes)
+        /// instead of LLM telemetry. Group is always (hook, outcome).
+        #[arg(long)]
+        hooks: bool,
+
+        /// When `--hooks` is set, restrict to a single hook (e.g. `stop-curate`).
+        #[arg(long)]
+        hook: Option<String>,
+    },
+
+    /// Internal/experimental commands for instrumentation.
+    /// Schema and flags may change between versions.
+    Debug {
+        #[command(subcommand)]
+        action: DebugAction,
     },
 
     /// Launch the Rememora Desktop app (Tauri)
@@ -407,6 +423,39 @@ enum Commands {
     Telemetry {
         #[command(subcommand)]
         action: TelemetryAction,
+    },
+}
+
+#[derive(Subcommand)]
+enum DebugAction {
+    /// Record a plugin hook gate-outcome event into `hook_invocations`.
+    /// Used by `plugin/scripts/stop-curate.sh`. Schema is experimental —
+    /// do not depend on column shape.
+    RecordHookEvent {
+        /// Hook name (currently only `stop-curate`).
+        #[arg(long)]
+        hook: String,
+
+        /// Gate outcome: `env_var_short_circuit`, `pgrep_short_circuit`,
+        /// `cooldown_short_circuit`, or `passed_through`.
+        #[arg(long)]
+        outcome: String,
+
+        /// Claude Code session_id (optional).
+        #[arg(long)]
+        session_id: Option<String>,
+
+        /// Parent session id, if applicable (optional).
+        #[arg(long)]
+        parent_session: Option<String>,
+
+        /// Cooldown stamp state: `fresh`, `within_window`, `expired`, `unknown`.
+        #[arg(long)]
+        cooldown_state: Option<String>,
+
+        /// Free-form JSON for forward-compat fields (optional).
+        #[arg(long)]
+        extra: Option<String>,
     },
 }
 
@@ -871,11 +920,42 @@ fn main() -> Result<()> {
             commands::export::run(&conn, project.as_deref(), &format)
         }
 
-        Commands::Usage { since, by } => commands::usage::run(
+        Commands::Usage {
+            since,
+            by,
+            hooks,
+            hook,
+        } => commands::usage::run(
             &conn,
-            &commands::usage::UsageArgs { since, by },
+            &commands::usage::UsageArgs {
+                since,
+                by,
+                hooks,
+                hook,
+            },
             cli.json,
         ),
+
+        Commands::Debug { action } => match action {
+            DebugAction::RecordHookEvent {
+                hook,
+                outcome,
+                session_id,
+                parent_session,
+                cooldown_state,
+                extra,
+            } => commands::debug_hook::record(
+                &conn,
+                &commands::debug_hook::RecordHookEventArgs {
+                    hook,
+                    outcome,
+                    session_id,
+                    parent_session,
+                    cooldown_state,
+                    extra,
+                },
+            ),
+        },
 
         Commands::Telemetry { action } => match action {
             TelemetryAction::ExportOtlp {

--- a/src/migrations/005_hook_invocations.sql
+++ b/src/migrations/005_hook_invocations.sql
@@ -1,0 +1,34 @@
+-- ─── Migration 005: hook-invocation telemetry ────────────────────────────────
+-- One row per Stop-hook invocation, capturing which recursion gate fired (or
+-- whether the curate spawn proceeded). Used to validate that the existing
+-- env-var + pgrep gates are sufficient before we consider a DB-backed gate.
+--
+-- Distinct from `agent_invocations` because hook events carry no token/cost
+-- columns and aggregate differently (counts per (hook, outcome), not cost).
+--
+-- Inserted from a single site:
+--   * `plugin/scripts/stop-curate.sh` via `rememora debug record-hook-event`
+--
+-- Schema is experimental — the `extra` JSON column exists so we can add
+-- forward-compat fields without a migration churn during the validation
+-- window.
+
+CREATE TABLE IF NOT EXISTS hook_invocations (
+    id              TEXT PRIMARY KEY,
+    ts              TEXT NOT NULL,
+    hook            TEXT NOT NULL,
+    outcome         TEXT NOT NULL,
+    session_id      TEXT,
+    parent_session  TEXT,
+    cooldown_state  TEXT,
+    extra           TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_hook_invocations_ts
+    ON hook_invocations(ts DESC);
+CREATE INDEX IF NOT EXISTS idx_hook_invocations_hook_ts
+    ON hook_invocations(hook, ts DESC);
+CREATE INDEX IF NOT EXISTS idx_hook_invocations_outcome
+    ON hook_invocations(outcome);
+CREATE INDEX IF NOT EXISTS idx_hook_invocations_session
+    ON hook_invocations(session_id);

--- a/src/models/hook_invocation.rs
+++ b/src/models/hook_invocation.rs
@@ -1,0 +1,252 @@
+//! Per-invocation telemetry for plugin hooks.
+//!
+//! Used to validate that the existing curate-recursion gates (env-var +
+//! pgrep + cooldown) are sufficient in production. Each call to
+//! `plugin/scripts/stop-curate.sh` emits one row at the gate-exit point,
+//! recording which gate (if any) short-circuited the curate spawn.
+//!
+//! Writers land here from a single site:
+//! - `commands::debug_hook::record` (invoked by `stop-curate.sh`)
+//!
+//! Readers are `rememora usage --hooks` (aggregation).
+//!
+//! Schema is experimental — the `extra` column is a JSON blob so we can add
+//! forward-compat fields without a migration churn during validation.
+
+use anyhow::{anyhow, Result};
+use rusqlite::{params, Connection};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HookKind {
+    StopCurate,
+}
+
+impl HookKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            HookKind::StopCurate => "stop-curate",
+        }
+    }
+
+    pub fn parse(s: &str) -> Result<Self> {
+        match s {
+            "stop-curate" => Ok(HookKind::StopCurate),
+            other => Err(anyhow!("unknown hook kind: {other}")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Outcome {
+    /// The `REMEMORA_CURATE_CHILD=1` env var was set — we are running inside
+    /// a curate-spawned subagent and must not re-curate.
+    EnvVarShortCircuit,
+    /// The `pgrep` gate matched a concurrent curate for this session.
+    PgrepShortCircuit,
+    /// The cooldown stamp file is within `REMEMORA_CURATE_COOLDOWN_SECS`.
+    CooldownShortCircuit,
+    /// No gate fired; the curate spawn proceeded.
+    PassedThrough,
+}
+
+impl Outcome {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Outcome::EnvVarShortCircuit => "env_var_short_circuit",
+            Outcome::PgrepShortCircuit => "pgrep_short_circuit",
+            Outcome::CooldownShortCircuit => "cooldown_short_circuit",
+            Outcome::PassedThrough => "passed_through",
+        }
+    }
+
+    pub fn parse(s: &str) -> Result<Self> {
+        match s {
+            "env_var_short_circuit" => Ok(Outcome::EnvVarShortCircuit),
+            "pgrep_short_circuit" => Ok(Outcome::PgrepShortCircuit),
+            "cooldown_short_circuit" => Ok(Outcome::CooldownShortCircuit),
+            "passed_through" => Ok(Outcome::PassedThrough),
+            other => Err(anyhow!("unknown outcome: {other}")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct HookEventRecord {
+    pub hook: &'static str,
+    pub outcome: &'static str,
+    pub session_id: Option<String>,
+    pub parent_session: Option<String>,
+    pub cooldown_state: Option<String>,
+    pub extra: Option<String>,
+}
+
+pub fn insert(conn: &Connection, record: &HookEventRecord) -> Result<String> {
+    let id = ulid::Ulid::new().to_string();
+    let ts = chrono::Utc::now().to_rfc3339();
+
+    conn.execute(
+        "INSERT INTO hook_invocations (
+            id, ts, hook, outcome, session_id, parent_session, cooldown_state, extra
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        params![
+            id,
+            ts,
+            record.hook,
+            record.outcome,
+            record.session_id,
+            record.parent_session,
+            record.cooldown_state,
+            record.extra,
+        ],
+    )?;
+
+    Ok(id)
+}
+
+/// Best-effort insert that never raises.
+///
+/// Telemetry must not break the caller. If the DB is unreachable or the
+/// schema drifted, swallow the error and return without propagating.
+pub fn try_insert(conn: &Connection, record: &HookEventRecord) {
+    if let Err(e) = insert(conn, record) {
+        eprintln!("warn: hook_invocation insert failed: {e}");
+    }
+}
+
+// ── Aggregation ─────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HookAggregate {
+    pub hook: String,
+    pub outcome: String,
+    pub count: i64,
+}
+
+/// Aggregate hook invocations since an ISO8601 cutoff (inclusive).
+///
+/// Returns one row per `(hook, outcome)` pair, ordered by count desc.
+/// `since` is `NULL`-safe: pass `None` to aggregate all history.
+/// `hook_filter` restricts to a single hook kind.
+pub fn aggregate_by_outcome(
+    conn: &Connection,
+    since: Option<&str>,
+    hook_filter: Option<&str>,
+) -> Result<Vec<HookAggregate>> {
+    let sql = "SELECT hook, outcome, COUNT(*) AS n
+               FROM hook_invocations
+               WHERE (?1 IS NULL OR ts >= ?1)
+                 AND (?2 IS NULL OR hook = ?2)
+               GROUP BY hook, outcome
+               ORDER BY n DESC, hook ASC, outcome ASC";
+
+    let mut stmt = conn.prepare(sql)?;
+    let rows = stmt
+        .query_map(params![since, hook_filter], |row| {
+            Ok(HookAggregate {
+                hook: row.get(0)?,
+                outcome: row.get(1)?,
+                count: row.get(2)?,
+            })
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+
+    Ok(rows)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db;
+
+    fn rec(outcome: Outcome, session: Option<&str>) -> HookEventRecord {
+        HookEventRecord {
+            hook: HookKind::StopCurate.as_str(),
+            outcome: outcome.as_str(),
+            session_id: session.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn insert_returns_ulid() {
+        let conn = db::open_memory().unwrap();
+        let id = insert(&conn, &rec(Outcome::PassedThrough, Some("s1"))).unwrap();
+        // ULID is 26 chars
+        assert_eq!(id.len(), 26);
+    }
+
+    #[test]
+    fn aggregate_groups_by_outcome() {
+        let conn = db::open_memory().unwrap();
+        insert(&conn, &rec(Outcome::PassedThrough, Some("s1"))).unwrap();
+        insert(&conn, &rec(Outcome::PassedThrough, Some("s2"))).unwrap();
+        insert(&conn, &rec(Outcome::PgrepShortCircuit, Some("s1"))).unwrap();
+        insert(&conn, &rec(Outcome::EnvVarShortCircuit, None)).unwrap();
+
+        let agg = aggregate_by_outcome(&conn, None, None).unwrap();
+        // 3 distinct outcomes
+        assert_eq!(agg.len(), 3);
+        // First (highest count) should be passed_through with 2
+        assert_eq!(agg[0].outcome, "passed_through");
+        assert_eq!(agg[0].count, 2);
+    }
+
+    #[test]
+    fn aggregate_filters_by_hook() {
+        let conn = db::open_memory().unwrap();
+        insert(&conn, &rec(Outcome::PassedThrough, Some("s1"))).unwrap();
+
+        let agg = aggregate_by_outcome(&conn, None, Some("stop-curate")).unwrap();
+        assert_eq!(agg.len(), 1);
+
+        let agg_none = aggregate_by_outcome(&conn, None, Some("nonexistent")).unwrap();
+        assert!(agg_none.is_empty());
+    }
+
+    #[test]
+    fn since_filter_excludes_old_rows() {
+        let conn = db::open_memory().unwrap();
+        // Direct insert with stale ts
+        conn.execute(
+            "INSERT INTO hook_invocations (id, ts, hook, outcome) VALUES
+             ('old', '1999-01-01T00:00:00Z', 'stop-curate', 'passed_through')",
+            [],
+        )
+        .unwrap();
+        insert(&conn, &rec(Outcome::PassedThrough, Some("s1"))).unwrap();
+
+        let recent = aggregate_by_outcome(&conn, Some("2020-01-01T00:00:00Z"), None).unwrap();
+        assert_eq!(recent.len(), 1);
+        assert_eq!(recent[0].count, 1);
+    }
+
+    #[test]
+    fn try_insert_does_not_panic_on_bad_schema() {
+        let conn = db::open_memory().unwrap();
+        conn.execute("DROP TABLE hook_invocations", []).unwrap();
+        try_insert(&conn, &rec(Outcome::PassedThrough, Some("s1")));
+    }
+
+    #[test]
+    fn outcome_enum_roundtrip() {
+        for o in [
+            Outcome::EnvVarShortCircuit,
+            Outcome::PgrepShortCircuit,
+            Outcome::CooldownShortCircuit,
+            Outcome::PassedThrough,
+        ] {
+            assert_eq!(Outcome::parse(o.as_str()).unwrap(), o);
+        }
+        assert!(Outcome::parse("nope").is_err());
+    }
+
+    #[test]
+    fn hook_enum_roundtrip() {
+        assert_eq!(
+            HookKind::parse(HookKind::StopCurate.as_str()).unwrap(),
+            HookKind::StopCurate
+        );
+        assert!(HookKind::parse("nope").is_err());
+    }
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,5 +1,6 @@
 pub mod agent_invocation;
 pub mod context;
+pub mod hook_invocation;
 pub mod project;
 pub mod relation;
 pub mod session;

--- a/tests/test_db.rs
+++ b/tests/test_db.rs
@@ -71,5 +71,5 @@ fn test_migrations_idempotent() {
     let count: i64 = conn
         .query_row("SELECT COUNT(*) FROM _migrations", [], |r| r.get(0))
         .unwrap();
-    assert_eq!(count, 4);
+    assert_eq!(count, 5);
 }

--- a/tests/test_hook_invocations.rs
+++ b/tests/test_hook_invocations.rs
@@ -1,0 +1,88 @@
+//! Integration tests for the `hook_invocations` table and its public API.
+//!
+//! Mirrors the unit tests but exercises the full migration path against a
+//! freshly-opened in-memory DB.
+
+mod common;
+
+use rememora::models::hook_invocation::{
+    self, aggregate_by_outcome, HookEventRecord, HookKind, Outcome,
+};
+
+#[test]
+fn migration_creates_hook_invocations_table() {
+    let conn = common::create_test_db();
+    let exists: bool = conn
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='hook_invocations')",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert!(exists, "hook_invocations table should exist after migrate");
+}
+
+#[test]
+fn insert_and_aggregate_by_outcome() {
+    let conn = common::create_test_db();
+
+    for o in [
+        Outcome::PassedThrough,
+        Outcome::PassedThrough,
+        Outcome::PgrepShortCircuit,
+        Outcome::EnvVarShortCircuit,
+        Outcome::CooldownShortCircuit,
+    ] {
+        hook_invocation::insert(
+            &conn,
+            &HookEventRecord {
+                hook: HookKind::StopCurate.as_str(),
+                outcome: o.as_str(),
+                session_id: Some("sess-x".into()),
+                cooldown_state: Some("fresh".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    }
+
+    let agg = aggregate_by_outcome(&conn, None, Some("stop-curate")).unwrap();
+    assert_eq!(agg.len(), 4); // 4 distinct outcomes
+    assert_eq!(agg[0].outcome, "passed_through"); // highest count
+    assert_eq!(agg[0].count, 2);
+
+    // Total invocations across outcomes
+    let total: i64 = agg.iter().map(|r| r.count).sum();
+    assert_eq!(total, 5);
+}
+
+#[test]
+fn since_filter_excludes_old_rows() {
+    let conn = common::create_test_db();
+
+    // Stale row inserted directly with explicit ts
+    conn.execute(
+        "INSERT INTO hook_invocations (id, ts, hook, outcome) VALUES
+         ('old1', '1990-01-01T00:00:00Z', 'stop-curate', 'passed_through')",
+        [],
+    )
+    .unwrap();
+
+    hook_invocation::insert(
+        &conn,
+        &HookEventRecord {
+            hook: HookKind::StopCurate.as_str(),
+            outcome: Outcome::PassedThrough.as_str(),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let recent = aggregate_by_outcome(&conn, Some("2020-01-01T00:00:00Z"), None).unwrap();
+    let total: i64 = recent.iter().map(|r| r.count).sum();
+    assert_eq!(total, 1);
+
+    let all = aggregate_by_outcome(&conn, None, None).unwrap();
+    let total_all: i64 = all.iter().map(|r| r.count).sum();
+    assert_eq!(total_all, 2);
+}


### PR DESCRIPTION
Closes #82.

## Summary

Adds **observability only** for the two existing curate-recursion gates so we can decide (after 2–4 weeks of data) whether they're sufficient or whether a DB-backed session-aware gate is actually needed. **No new gate is added.**

- New `hook_invocations` table (migration 005) — small, dedicated, separate from `agent_invocations` (which carries token/cost columns meaningless for hook events).
- New private/experimental verb `rememora debug record-hook-event` writes one row per Stop-hook gate-exit. Uses `try_insert` so a locked/missing DB never propagates.
- New `rememora usage --hooks` flag aggregates by `(hook, outcome)`. Reuses existing `--since` parsing. Optional `--hook` filter narrows to a single hook.
- `plugin/scripts/stop-curate.sh` emits at each gate-exit point via a backgrounded, fully-redirected `_emit` helper.

## Sample readout

```
$ rememora usage --hooks --since 7d
hook             outcome                         calls
--------------------------------------------------------
stop-curate      passed_through                      2
stop-curate      env_var_short_circuit               1
stop-curate      pgrep_short_circuit                 1
--------------------------------------------------------
TOTAL                                                4
```

JSON mode is supported via the global `--json` flag.

## Schema

```sql
CREATE TABLE hook_invocations (
    id              TEXT PRIMARY KEY,        -- ULID
    ts              TEXT NOT NULL,           -- RFC3339
    hook            TEXT NOT NULL,           -- 'stop-curate' (extensible)
    outcome         TEXT NOT NULL,           -- env_var_short_circuit | pgrep_short_circuit
                                              --  | cooldown_short_circuit | passed_through
    session_id      TEXT,
    parent_session  TEXT,                    -- nullable; reserved for cross-session correlation
    cooldown_state  TEXT,                    -- 'fresh' | 'within_window' | 'expired' | 'unknown'
    extra           TEXT                     -- JSON blob for forward compat
);
```

Indexes on `ts DESC`, `(hook, ts DESC)`, `outcome`, `session_id`.

## Resilience

- The shell hook **never blocks on telemetry**: `_emit` backgrounds the rememora call in a subshell with `</dev/null >/dev/null 2>&1`, returns 0 unconditionally, and exits early if `rememora` is missing on PATH.
- The Rust insert path uses `try_insert` — a missing/dropped table emits a `warn:` to stderr but doesn't propagate.

## Out of scope (per ticket)

- A third gate (DB-backed session-aware) — explicitly deferred until this data lands.
- Backfill of historical data — only forward emission counts.
- OTLP export of hook events (`agent_invocations` keeps owning OTEL).

## Test plan

- [x] `cargo test` — 73 lib tests + integration tests all pass (added: `models::hook_invocation` unit tests, `commands::debug_hook` unit tests, `tests/test_hook_invocations.rs`, updated migration count assertion in `tests/test_db.rs`).
- [x] `cargo clippy -- -D warnings` — clean (matches CI).
- [x] Local end-to-end smoke against a scratch DB:
    - `REMEMORA_DB=/tmp/x.db rememora debug record-hook-event ...` writes a row.
    - `REMEMORA_DB=/tmp/x.db rememora usage --hooks --since all` reads it back.
    - Invoking `stop-curate.sh` with `REMEMORA_CURATE_CHILD=1` set triggers the env-var gate and records an `env_var_short_circuit` row.

## Memory

Saved per CLAUDE.md guidance:
- **Decision**: schema choice (new `hook_invocations` vs reusing `agent_invocations`).
- **Entity**: `rememora debug record-hook-event` verb + `hook_invocations` table.
- **Pattern**: "shell never blocks on telemetry" — backgrounded + redirected emission.