### PR TITLE
chore: ignore agent runtime scratch dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 .remember/
 .agents/locks/
 .agents/worktrees/
+.agents/board_raw.json
+.claude/agent-memory/
+.claude/worktrees/
 
 # Bench
 bench/node_modules/


### PR DESCRIPTION
## Summary

Add three per-machine agent runtime paths to `.gitignore` so they stop showing up in `git status`:

- `.agents/board_raw.json` — triage agent's raw GH project board dump
- `.claude/agent-memory/` — Claude Code subagent memory store
- `.claude/worktrees/` — Claude Code agent worktree stubs (often locked)

Sits alongside the existing `.agents/locks/` and `.agents/worktrees/` entries that ignore the same class of artifact.

## Test plan

- [x] `git status` is clean on a fresh checkout that has any of these dirs.
- [x] No source files touched — CI is incidental.