### PR TITLE
fix(search,context): FTS5 OR support; aggregate Global context across projects (#103, #104)

### DIFF
--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -45,7 +45,11 @@ fn rememora_hooks() -> &'static [HookSpec] {
             // `--format context`. Inlined here so the CLI-only install path
             // does not depend on plugin scripts being present on disk.
             marker: REMEMORA_PROMPT_HOOK_MARKER,
-            command: "bash -c 'p=$(cat 2>/dev/null | python3 -c \"import sys,json; d=json.load(sys.stdin); print(d.get(\\\"prompt\\\",\\\"\\\"))\" 2>/dev/null); [ ${#p} -ge 6 ] && rememora search --limit 3 --format context \"$(printf %s \"$p\" | tr -d \"?:\\\"()*-\" | tr -s \" \")\" 2>/dev/null || true'",
+            // Defense-in-depth for #103: even though `rememora search` falls
+            // back to a literal-token query on FTS5 syntax errors, strip the
+            // word-bounded operators (OR/AND/NOT/NEAR) and structural punct
+            // here too so the search call sees a plain bag of words.
+            command: "bash -c 'p=$(cat 2>/dev/null | python3 -c \"import sys,json,re;d=json.load(sys.stdin);s=d.get(\\\"prompt\\\",\\\"\\\");s=re.sub(r\\\"\\\\b(OR|AND|NOT|NEAR)\\\\b\\\",\\\" \\\",s);s=re.sub(r\\\"[\\\\\\\"()*?:\\\\-]\\\",\\\" \\\",s);print(re.sub(r\\\"\\\\s+\\\",\\\" \\\",s).strip())\" 2>/dev/null); [ ${#p} -ge 6 ] && rememora search --limit 3 --format context \"$p\" 2>/dev/null || true'",
         },
         HookSpec {
             event: "SessionEnd",

--- a/src/format.rs
+++ b/src/format.rs
@@ -30,6 +30,8 @@ pub fn context_to_markdown(assembly: &ContextAssembly) -> String {
         md.push('\n');
     }
 
+    let global_mode = assembly.project_name.is_none();
+
     // L0 abstracts — memory map
     if !assembly.l0_abstracts.is_empty() {
         md.push_str("## Memory Map (L0)\n\n");
@@ -39,10 +41,18 @@ pub fn context_to_markdown(assembly: &ContextAssembly) -> String {
                 .category
                 .as_deref()
                 .unwrap_or(&scored.context.context_type);
-            md.push_str(&format!(
-                "- [{}] {} (importance: {:.1})\n",
-                cat, scored.context.abstract_text, scored.context.importance
-            ));
+            if global_mode {
+                let proj = project_label_for(&scored.context.uri);
+                md.push_str(&format!(
+                    "- [{}] [{}] {} (importance: {:.1})\n",
+                    proj, cat, scored.context.abstract_text, scored.context.importance
+                ));
+            } else {
+                md.push_str(&format!(
+                    "- [{}] {} (importance: {:.1})\n",
+                    cat, scored.context.abstract_text, scored.context.importance
+                ));
+            }
         }
         md.push('\n');
     }
@@ -59,16 +69,41 @@ pub fn context_to_markdown(assembly: &ContextAssembly) -> String {
                 .category
                 .as_deref()
                 .unwrap_or(&scored.context.context_type);
-            md.push_str(&format!("### [{}] {}\n\n", cat, scored.context.name));
+            if global_mode {
+                let proj = project_label_for(&scored.context.uri);
+                md.push_str(&format!(
+                    "### [{}] [{}] {}\n\n",
+                    proj, cat, scored.context.name
+                ));
+            } else {
+                md.push_str(&format!("### [{}] {}\n\n", cat, scored.context.name));
+            }
             md.push_str(&format!("{}\n\n", scored.context.overview));
         }
     }
 
     if assembly.l0_abstracts.is_empty() && assembly.latest_session.is_none() {
-        md.push_str("*No memories or sessions found for this project.*\n");
+        if global_mode {
+            md.push_str("*No memories found in the database.*\n");
+        } else {
+            md.push_str("*No memories or sessions found for this project.*\n");
+        }
     }
 
     md
+}
+
+/// Render a short label for the project a context belongs to, used in
+/// Global-mode context output. Falls back to `global` for global-scoped
+/// memories and `?` for unparseable URIs.
+fn project_label_for(uri: &str) -> String {
+    if let Some(name) = crate::uri::extract_project(uri) {
+        return name;
+    }
+    if uri.starts_with("rememora://global/") {
+        return "global".to_string();
+    }
+    "?".to_string()
 }
 
 pub fn search_results_to_markdown(results: &[SearchResult]) -> String {

--- a/src/hierarchy.rs
+++ b/src/hierarchy.rs
@@ -18,7 +18,14 @@ pub struct ScoredContext {
     pub score: f64,
 }
 
-/// Get L0 map: all global preferences + project contexts as abstracts
+/// Get L0 map: scored, ranked abstracts.
+///
+/// - When `project` is `Some(...)`, returns global preferences plus the
+///   project's own contexts (the original behavior).
+/// - When `project` is `None` (Global mode — typically `context --auto` from
+///   an unregistered cwd), aggregates across **every** project plus globals
+///   so the user sees memories from the rest of their workspace instead of an
+///   empty page. Issue #104.
 pub fn get_l0_map(conn: &Connection, project: Option<&str>) -> Result<Vec<ScoredContext>> {
     let mut all = Vec::new();
 
@@ -32,12 +39,31 @@ pub fn get_l0_map(conn: &Connection, project: Option<&str>) -> Result<Vec<Scored
         }
     }
 
-    // Project-scoped contexts
-    if let Some(proj) = project {
-        let project_contexts = context::list_by_scope(conn, None, None, Some(proj), 100)?;
-        for ctx in project_contexts {
-            let score = compute_score(&ctx);
-            all.push(ScoredContext { context: ctx, score });
+    match project {
+        Some(proj) => {
+            // Project-scoped contexts
+            let project_contexts = context::list_by_scope(conn, None, None, Some(proj), 100)?;
+            for ctx in project_contexts {
+                let score = compute_score(&ctx);
+                all.push(ScoredContext { context: ctx, score });
+            }
+        }
+        None => {
+            // Global mode: aggregate across every registered project so the
+            // L0 page is informative even when cwd is not a known project.
+            // We pull a generous cap (200) and let the score-sort below
+            // surface the highest-signal entries.
+            let everything = context::list_by_scope(conn, Some("memory"), None, None, 200)?;
+            // Skip globals already added above (avoid duplicates).
+            let already: std::collections::HashSet<String> =
+                all.iter().map(|s| s.context.id.clone()).collect();
+            for ctx in everything {
+                if already.contains(&ctx.id) {
+                    continue;
+                }
+                let score = compute_score(&ctx);
+                all.push(ScoredContext { context: ctx, score });
+            }
         }
     }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -8,6 +8,81 @@ pub struct SearchResult {
     pub rank: f64,
 }
 
+/// Strip ASCII control chars (incl. NUL) and trim whitespace.
+fn sanitize_input(query: &str) -> String {
+    query
+        .chars()
+        .filter(|c| !c.is_control() || *c == '\t')
+        .collect::<String>()
+        .trim()
+        .to_string()
+}
+
+/// Tokens that, if present as standalone words, signal the user is writing
+/// FTS5 query syntax. Detection is case-sensitive — FTS5 itself only treats
+/// uppercase OR/AND/NOT/NEAR as operators.
+fn looks_like_fts5_syntax(q: &str) -> bool {
+    if q.contains('(') || q.contains(')') || q.contains('"') {
+        return true;
+    }
+    if q.contains('*') {
+        // prefix queries: a token ending with `*`
+        if q.split_whitespace().any(|t| t.ends_with('*') && t.len() > 1) {
+            return true;
+        }
+    }
+    for tok in q.split_whitespace() {
+        if matches!(tok, "OR" | "AND" | "NOT" | "NEAR") {
+            return true;
+        }
+    }
+    false
+}
+
+/// Pure bag-of-words OR query — the safe fallback. Drops tokens that are pure
+/// FTS5 punctuation so the resulting expression is always parseable.
+fn safe_or_query(q: &str) -> Option<String> {
+    let toks: Vec<String> = q
+        .split_whitespace()
+        .map(|t| {
+            t.chars()
+                .filter(|c| !matches!(c, '(' | ')' | '"' | '*' | ':'))
+                .collect::<String>()
+        })
+        .filter(|t| !t.is_empty())
+        .map(|t| {
+            // Wrap each token in double quotes to defang any leftover FTS5
+            // operators (e.g. a bare "OR" token in the bag would otherwise
+            // be re-interpreted as the operator on retry).
+            format!("\"{}\"", t.replace('"', ""))
+        })
+        .collect();
+    if toks.is_empty() {
+        None
+    } else {
+        Some(toks.join(" OR "))
+    }
+}
+
+/// Build the primary FTS5 query string from the user's input.
+///
+/// - If the user wrote operator syntax (OR/AND/NOT/NEAR/parens/quotes/prefix
+///   `*`), pass it through verbatim — power users get full FTS5 power.
+/// - Otherwise, default to an OR-join across the bag of words to preserve the
+///   prior implicit-OR recall behavior.
+///
+/// Returns `None` for empty / whitespace-only queries.
+fn build_fts_query(query: &str) -> Option<String> {
+    let cleaned = sanitize_input(query);
+    if cleaned.is_empty() {
+        return None;
+    }
+    if looks_like_fts5_syntax(&cleaned) {
+        return Some(cleaned);
+    }
+    safe_or_query(&cleaned)
+}
+
 pub fn search(
     conn: &Connection,
     query: &str,
@@ -15,17 +90,50 @@ pub fn search(
     category: Option<&str>,
     limit: usize,
 ) -> Result<Vec<SearchResult>> {
-    // Build FTS5 query — escape special characters
-    let fts_query = query
-        .replace('"', "\"\"")
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" OR ");
-
-    if fts_query.is_empty() {
+    let Some(fts_query) = build_fts_query(query) else {
         return Ok(vec![]);
+    };
+    match search_with_fts(conn, &fts_query, project, category, limit) {
+        Ok(rows) => Ok(rows),
+        Err(e) => {
+            // Defense-in-depth: if FTS5 rejected the user's syntax, retry
+            // with a guaranteed-safe OR-of-bag-of-words form. This covers
+            // unbalanced parens, lone double-quotes, malformed NEAR, etc.
+            if is_fts5_syntax_error(&e) {
+                let cleaned = sanitize_input(query);
+                if let Some(fallback) = safe_or_query(&cleaned) {
+                    if fallback != fts_query {
+                        return search_with_fts(conn, &fallback, project, category, limit);
+                    }
+                }
+                return Ok(vec![]);
+            }
+            Err(e)
+        }
     }
+}
 
+/// Heuristic: did a SQL execute fail because FTS5 rejected the user's query
+/// expression? FTS5 raises a few distinct messages depending on what it
+/// disliked — "syntax error near …", "unterminated string", "no such column"
+/// (when an unbalanced phrase confuses its column-filter parser), etc. The
+/// goal is to fall back to the safe-OR query whenever the user's input was
+/// the cause, but bubble up genuine SQL errors (DB locked, missing table).
+fn is_fts5_syntax_error(e: &anyhow::Error) -> bool {
+    let msg = e.to_string().to_lowercase();
+    msg.contains("fts5")
+        || msg.contains("unterminated string")
+        || msg.contains("syntax error")
+        || msg.contains("malformed match")
+}
+
+fn search_with_fts(
+    conn: &Connection,
+    fts_query: &str,
+    project: Option<&str>,
+    category: Option<&str>,
+    limit: usize,
+) -> Result<Vec<SearchResult>> {
     let mut sql = String::from(
         "SELECT c.id, c.uri, c.parent_uri, c.context_type, c.category, c.name,
                 c.abstract, c.overview, c.content, c.tags, c.source_agent,
@@ -38,7 +146,7 @@ pub fn search(
     );
 
     let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
-    param_values.push(Box::new(fts_query));
+    param_values.push(Box::new(fts_query.to_string()));
     let mut param_idx = 2;
 
     if let Some(proj) = project {

--- a/tests/behavior_search.rs
+++ b/tests/behavior_search.rs
@@ -242,6 +242,153 @@ fn context_format_empty_when_no_results() {
 }
 
 // ---------------------------------------------------------------------------
+// FTS5 query syntax (Issue #103)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn search_supports_explicit_or_operator() {
+    // Given: two memories that share no common terms
+    let conn = db_with_memories(&[
+        memory("Redis caching")
+            .project("testproj")
+            .content("Picked Redis over memcached for caching"),
+        memory("Stampede prevention")
+            .project("testproj")
+            .content("Thundering herd workaround using locks"),
+    ]);
+
+    // When: using FTS5's explicit OR operator
+    let results = rememora::search::search(&conn, "redis OR stampede", None, None, 10).unwrap();
+
+    // Then: both memories appear (no FTS5 syntax error)
+    assert_eq!(results.len(), 2, "expected both branches of OR to match");
+}
+
+#[test]
+fn search_supports_grouped_or_and() {
+    // Given: memories with overlapping terms
+    let conn = db_with_memories(&[
+        memory("Redis caching layer")
+            .project("testproj")
+            .content("redis caching"),
+        memory("Memcached cache layer")
+            .project("testproj")
+            .content("memcached caching"),
+        memory("Unrelated note")
+            .project("testproj")
+            .content("nothing relevant"),
+    ]);
+
+    // When: using a grouped expression
+    let results =
+        rememora::search::search(&conn, "(redis OR memcached) AND caching", None, None, 10)
+            .unwrap();
+
+    // Then: both cache memories match, the unrelated one does not
+    assert!(results.iter().any(|r| r.context.name.contains("Redis")));
+    assert!(results.iter().any(|r| r.context.name.contains("Memcached")));
+    assert!(!results.iter().any(|r| r.context.name.contains("Unrelated")));
+}
+
+#[test]
+fn search_supports_phrase_query() {
+    // Given: a memory containing the exact phrase
+    let conn = db_with_memories(&[
+        memory("Locks and herds")
+            .project("testproj")
+            .content("Use a thundering herd lock"),
+        memory("Order matters")
+            .project("testproj")
+            // Same words, different order — must NOT match the phrase query.
+            .content("a herd thundering through"),
+    ]);
+
+    // When: using FTS5 phrase syntax
+    let results =
+        rememora::search::search(&conn, "\"thundering herd\"", None, None, 10).unwrap();
+
+    // Then: only the exact-phrase memory matches
+    assert!(results.iter().any(|r| r.context.name.contains("Locks")));
+    assert!(!results.iter().any(|r| r.context.name.contains("Order")));
+}
+
+#[test]
+fn search_supports_prefix_query() {
+    // Given: a memory containing "redis"
+    let conn = db_with_memories(&[memory("Redis pool")
+        .project("testproj")
+        .content("redis connection pool")]);
+
+    // When: using a prefix query
+    let results = rememora::search::search(&conn, "redi*", None, None, 10).unwrap();
+
+    // Then: it matches via the prefix
+    assert!(!results.is_empty(), "redi* should match redis");
+}
+
+#[test]
+fn search_empty_query_returns_empty_no_error() {
+    // Given: a populated DB
+    let conn = db_with_memories(&[memory("anything").project("testproj").content("x")]);
+
+    // When: passing empty / whitespace-only queries
+    let empty = rememora::search::search(&conn, "", None, None, 10).unwrap();
+    let blank = rememora::search::search(&conn, "   \t  ", None, None, 10).unwrap();
+
+    // Then: empty results, never an error
+    assert!(empty.is_empty());
+    assert!(blank.is_empty());
+}
+
+#[test]
+fn search_with_unbalanced_quote_falls_back_safely() {
+    // Given: a memory matching "redis"
+    let conn = db_with_memories(&[memory("Redis cache")
+        .project("testproj")
+        .content("redis cache")]);
+
+    // When: passing a query with a stray double-quote that would make FTS5
+    // unhappy (the primary query path passes quotes through)
+    let results = rememora::search::search(&conn, "redis \"", None, None, 10).unwrap();
+
+    // Then: the safe-fallback OR-of-tokens path runs and finds the memory
+    assert!(
+        !results.is_empty(),
+        "fallback should still surface the redis memory"
+    );
+}
+
+#[test]
+fn search_strips_control_characters() {
+    // Given: a populated DB
+    let conn = db_with_memories(&[memory("Redis cache")
+        .project("testproj")
+        .content("redis cache")]);
+
+    // When: query embeds NUL and other control bytes
+    let results = rememora::search::search(&conn, "redis\x00\x01\x02", None, None, 10).unwrap();
+
+    // Then: the control bytes are stripped and the search still works
+    assert!(
+        !results.is_empty(),
+        "control chars should be stripped, search should proceed"
+    );
+}
+
+#[test]
+fn search_with_or_in_lowercase_is_treated_as_term() {
+    // FTS5 only treats UPPERCASE OR as the operator. Lowercase "or" should
+    // be a regular search term — and the bag-of-words OR fallback we build
+    // for plain queries must not crash on it.
+    let conn = db_with_memories(&[memory("redis cache decision")
+        .project("testproj")
+        .content("we picked redis over memcache or anything else")]);
+
+    let results = rememora::search::search(&conn, "redis or memcache", None, None, 10).unwrap();
+    assert!(!results.is_empty(), "lowercase or is a literal token, not the operator");
+}
+
+// ---------------------------------------------------------------------------
 // Active count bumping
 // ---------------------------------------------------------------------------
 

--- a/tests/test_hierarchy.rs
+++ b/tests/test_hierarchy.rs
@@ -82,3 +82,93 @@ fn test_empty_project_assembly() {
 
     assert!(md.contains("No memories or sessions found"));
 }
+
+// Issue #104: when no project is detected (cwd is not inside a registered
+// project), Global mode used to filter to project=None and show an empty
+// memory map. The fix: aggregate across every project in the DB.
+#[test]
+fn test_global_mode_aggregates_across_projects() {
+    use rememora::models::context::{self, InsertContext};
+    use rememora::models::project;
+
+    let conn = common::create_test_db();
+
+    // Two projects, two memories each.
+    project::add(&conn, "alpha", Some("/tmp/alpha"), "Alpha project", &[]).unwrap();
+    project::add(&conn, "beta", Some("/tmp/beta"), "Beta project", &[]).unwrap();
+
+    for (proj, mems) in [
+        ("alpha", &["alpha decision one", "alpha pattern two"][..]),
+        ("beta", &["beta decision one", "beta pattern two"][..]),
+    ] {
+        for (i, name) in mems.iter().enumerate() {
+            let category = if i % 2 == 0 { "decision" } else { "pattern" };
+            context::insert(
+                &conn,
+                &InsertContext {
+                    uri: format!(
+                        "rememora://projects/{proj}/memories/{category}/m{i}-{}",
+                        slug::slugify(name)
+                    ),
+                    parent_uri: Some(format!(
+                        "rememora://projects/{proj}/memories/{category}"
+                    )),
+                    context_type: "memory".to_string(),
+                    category: Some(category.to_string()),
+                    name: name.to_string(),
+                    abstract_text: format!("abs: {name}"),
+                    overview: format!("ov: {name}"),
+                    content: format!("body: {name}"),
+                    tags: "[]".to_string(),
+                    source_agent: Some("claude-code".to_string()),
+                    source_session: None,
+                    importance: 0.5,
+                },
+            )
+            .unwrap();
+        }
+    }
+
+    // Assemble in Global mode.
+    let assembly = hierarchy::assemble(&conn, None).unwrap();
+
+    // Then: at least 4 entries surface (all memory rows from both projects),
+    // covering both project URIs.
+    assert!(
+        assembly.l0_abstracts.len() >= 4,
+        "expected aggregated view across projects, got {} entries",
+        assembly.l0_abstracts.len()
+    );
+
+    let uris: Vec<&str> = assembly
+        .l0_abstracts
+        .iter()
+        .map(|s| s.context.uri.as_str())
+        .collect();
+    assert!(uris.iter().any(|u| u.contains("alpha")), "missing alpha");
+    assert!(uris.iter().any(|u| u.contains("beta")), "missing beta");
+
+    // The rendered markdown should tag each entry with its project so the
+    // user can tell which workspace it came from.
+    let md = rememora::format::context_to_markdown(&assembly);
+    assert!(
+        md.contains("[alpha]"),
+        "Global L0 should prefix entries with project name; got:\n{md}"
+    );
+    assert!(md.contains("[beta]"));
+    // And it must not claim the DB is empty.
+    assert!(!md.contains("No memories"));
+}
+
+// Issue #104: when the DB really is empty, Global mode should still produce a
+// distinct, accurate empty-state message.
+#[test]
+fn test_global_mode_empty_db_message() {
+    let conn = common::create_test_db();
+    let assembly = hierarchy::assemble(&conn, None).unwrap();
+    let md = rememora::format::context_to_markdown(&assembly);
+    assert!(
+        md.contains("No memories found in the database"),
+        "expected accurate Global empty-state, got:\n{md}"
+    );
+}


### PR DESCRIPTION
Fixes #103 and #104.

## Summary

Two related bugs in search/context, fixed together because they share the same FTS5 query-builder code path.

### #103 — `rememora search` errored on FTS5 operators

`src/search.rs` joined user tokens on whitespace and re-joined with `" OR "`, so `redis OR stampede` became the malformed `redis OR OR OR stampede` and crashed FTS5. Power users couldn't use the FTS5 grammar at all.

**Before**
```
$ rememora search "redis OR stampede"
Error: fts5: syntax error near "OR"
```

**After**
```
$ rememora search "redis OR stampede"
## Search Results (2 found)

1. **[decision] Redis caching**
   ...
2. **[case] Stampede issue thundering herd**
   ...
```

The search command now:
- Detects FTS5 operator syntax (word-bounded `OR`/`AND`/`NOT`/`NEAR`, parens, double-quotes, prefix `*`) and passes it through verbatim — power users get the full grammar.
- For plain bag-of-words input, builds a quoted OR-join (preserving the prior implicit-OR recall behavior).
- Strips ASCII control chars / NULs from input.
- Falls back to a safe-OR form if FTS5 still rejects the input (covers stray quotes, malformed `NEAR`, etc) instead of bubbling up a SQL error.

The `UserPromptSubmit` hook injected by `rememora setup` is also hardened: the inline Python sanitizer now strips word-bounded `OR`/`AND`/`NOT`/`NEAR` plus parens/quotes/prefix-glob before passing to `rememora search`. Defense-in-depth.

### #104 — `context --auto` was empty in Global mode

From a non-registered cwd, `rememora context --auto` rendered an empty Global page even though `rememora search` (no filter) returned matches from every project. Cause: `hierarchy::get_l0_map(conn, None)` only pulled global-scoped *preferences*, never project-scoped memories.

**Before**
```
$ cd /tmp && rememora context --auto
# Rememora Context: Global

*No memories or sessions found for this project.*
```

**After**
```
$ cd /tmp && rememora context --auto
# Rememora Context: Global

## Memory Map (L0)

- [alpha] [decision] alpha decision one (importance: 0.5)
- [alpha] [pattern]  alpha pattern two (importance: 0.5)
- [beta]  [decision] beta decision one  (importance: 0.5)
- [beta]  [pattern]  beta pattern two   (importance: 0.5)
...
```

Global mode now:
- Aggregates every non-superseded memory across all registered projects plus globals (capped at 200, then score-ranked).
- Prefixes each L0 entry and L1 heading with `[<project>]` so it's obvious which workspace each memory came from.
- Shows the accurate empty-state `*No memories found in the database.*` only when the DB is genuinely empty.

Per-project context (`context --project foo`) is unchanged.

## Files changed

- `src/search.rs` — `build_fts_query` / `safe_or_query` / `is_fts5_syntax_error`; `search()` retries on syntax error.
- `src/commands/setup.rs` — `UserPromptSubmit` hook command sanitizes operators.
- `src/hierarchy.rs` — Global-mode branch in `get_l0_map`.
- `src/format.rs` — project-prefix in Global L0/L1; new empty-state message; `project_label_for` helper.
- `tests/behavior_search.rs` — 7 new cases (OR, grouped expr, phrase, prefix, empty/whitespace, control chars, unbalanced quote, lowercase `or`).
- `tests/test_hierarchy.rs` — 2 new cases (Global mode aggregates across projects; Global empty-state).

## Test plan

- [x] `cargo test` — 21 test binaries, 0 failures
- [x] `cargo clippy --lib --bins -- -D warnings` — clean
- [x] Manual end-to-end: `rememora search "redis OR stampede"` returns expected hits
- [x] Hook bash one-liner verified end-to-end with sample JSON: `redis OR stampede (foo) AND bar` → `redis stampede foo bar` before reaching `rememora search`
- [x] Existing `setup` idempotency tests pass (marker substring unchanged)

## Notes

- No version bump (0.x bug fixes).
- Vector-search path is untouched — its query is a precomputed embedding, not user text.
- `plugin/scripts/prompt-search.sh` is left for a follow-up — the immediate user-facing breakage was the inline hook string in `rememora setup`.