### PR TITLE
fix(setup,docker): keychain readback verify; deploy plugin hook scripts to ~/.rememora/hooks; eliminate .claude.json warning (#109, #110, #111)

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -21,6 +21,18 @@ if [[ -f "${SRC_KEY}" ]]; then
     install -m 0644 -o root -g root "${SRC_KEY}" "${DST_KEY}"
 fi
 
+# Issue #110: silence "Claude configuration file not found at: ~/.claude.json"
+# noise that `claude -p` prints 3+ times before responding inside the sandbox.
+# Cosmetic but loud. Seed an empty JSON object owned by the tester user. If
+# the user later runs `/login` and Claude Code populates the real file, this
+# placeholder is overwritten on first real write — idempotent.
+CLAUDE_CONFIG="/home/tester/.claude.json"
+if [[ ! -f "${CLAUDE_CONFIG}" ]]; then
+    echo '{}' > "${CLAUDE_CONFIG}"
+    chown tester:tester "${CLAUDE_CONFIG}"
+    chmod 0644 "${CLAUDE_CONFIG}"
+fi
+
 # Start a detached tmux session as the tester user. Idempotent: re-running
 # is a no-op if the session already exists.
 sudo -u tester -H bash -c '

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -2,9 +2,34 @@ use anyhow::{Context, Result};
 use std::path::PathBuf;
 
 const REMEMORA_MARKER: &str = "## Rememora";
-const REMEMORA_HOOK_MARKER: &str = "rememora context --auto";
-const REMEMORA_CURATE_MARKER: &str = "rememora curate";
-const REMEMORA_PROMPT_HOOK_MARKER: &str = "rememora search --limit 3";
+
+// Markers identifying canonical Rememora hook entries. These are substring
+// fingerprints used by `hooks_already_configured` to confirm the deployed
+// command is in place. They reference the deployed-script paths under
+// `~/.rememora/hooks/` so the marker tracks the exact form `setup --apply`
+// writes today (issue #111).
+const REMEMORA_HOOK_MARKER: &str = ".rememora/hooks/session-start.sh";
+const REMEMORA_CURATE_MARKER: &str = ".rememora/hooks/stop-curate.sh";
+const REMEMORA_PROMPT_HOOK_MARKER: &str = ".rememora/hooks/prompt-search.sh";
+const REMEMORA_SESSION_END_MARKER: &str = ".rememora/hooks/session-end.sh";
+
+// Bundled plugin hook scripts — embedded at compile time so CLI-only
+// installs (Homebrew, cargo) get the same observability-instrumented
+// scripts the marketplace plugin ships (issue #111). On every
+// `setup --apply` we redeploy these to `~/.rememora/hooks/<name>.sh`
+// so they upgrade in lockstep with the CLI binary.
+const BUNDLED_SESSION_START_SH: &str = include_str!("../../plugin/scripts/session-start.sh");
+const BUNDLED_SESSION_END_SH: &str = include_str!("../../plugin/scripts/session-end.sh");
+const BUNDLED_STOP_CURATE_SH: &str = include_str!("../../plugin/scripts/stop-curate.sh");
+const BUNDLED_PROMPT_SEARCH_SH: &str = include_str!("../../plugin/scripts/prompt-search.sh");
+
+/// Filename + content pairs for every script we redeploy under `~/.rememora/hooks/`.
+const BUNDLED_HOOK_SCRIPTS: &[(&str, &str)] = &[
+    ("session-start.sh", BUNDLED_SESSION_START_SH),
+    ("session-end.sh", BUNDLED_SESSION_END_SH),
+    ("stop-curate.sh", BUNDLED_STOP_CURATE_SH),
+    ("prompt-search.sh", BUNDLED_PROMPT_SEARCH_SH),
+];
 
 /// Embedded canonical hook manifest — single source of truth for hook *shape*.
 ///
@@ -38,35 +63,37 @@ fn rememora_hooks() -> &'static [HookSpec] {
     // `plugin/hooks/hooks.json` (validated by `setup_hooks_match_manifest_subset`).
     // We deliberately exclude `Setup`: it's a marketplace-only event whose
     // command depends on `${CLAUDE_PLUGIN_ROOT}` and has no CLI-install analogue.
+    //
+    // Issue #111: each command points at the bundled plugin script deployed
+    // to `~/.rememora/hooks/<name>.sh` by `deploy_hook_scripts()`. This gives
+    // CLI installs (Homebrew, cargo) the same `_emit` recursion-gate
+    // telemetry (`hook_invocations` table) the marketplace plugin already
+    // had, and lets the scripts upgrade in lockstep with the CLI binary
+    // (every `setup --apply` redeploys them).
+    //
+    // Tilde expansion is performed by the shell that runs the hook command;
+    // Claude Code launches hooks via `bash -c`, so `~` resolves correctly
+    // without us having to bake an absolute path that would differ per host.
     &[
         HookSpec {
             event: "SessionStart",
-            // "rememora context --auto" — narrow enough that user-pasted hooks
-            // with arbitrary other rememora commands won't false-match.
             marker: REMEMORA_HOOK_MARKER,
-            command: "rememora context --auto 2>/dev/null || true",
+            command: "bash ~/.rememora/hooks/session-start.sh 2>/dev/null || true",
         },
         HookSpec {
             event: "UserPromptSubmit",
-            // Mirrors plugin/scripts/prompt-search.sh: bounded FTS5 hits via
-            // `--format context`. Inlined here so the CLI-only install path
-            // does not depend on plugin scripts being present on disk.
             marker: REMEMORA_PROMPT_HOOK_MARKER,
-            // Defense-in-depth for #103: even though `rememora search` falls
-            // back to a literal-token query on FTS5 syntax errors, strip the
-            // word-bounded operators (OR/AND/NOT/NEAR) and structural punct
-            // here too so the search call sees a plain bag of words.
-            command: "bash -c 'p=$(cat 2>/dev/null | python3 -c \"import sys,json,re;d=json.load(sys.stdin);s=d.get(\\\"prompt\\\",\\\"\\\");s=re.sub(r\\\"\\\\b(OR|AND|NOT|NEAR)\\\\b\\\",\\\" \\\",s);s=re.sub(r\\\"[\\\\\\\"()*?:\\\\-]\\\",\\\" \\\",s);print(re.sub(r\\\"\\\\s+\\\",\\\" \\\",s).strip())\" 2>/dev/null); [ ${#p} -ge 6 ] && rememora search --limit 3 --format context \"$p\" 2>/dev/null || true'",
+            command: "bash ~/.rememora/hooks/prompt-search.sh 2>/dev/null || true",
         },
         HookSpec {
             event: "SessionEnd",
-            marker: "rememora session end-active",
-            command: "rememora session end-active --auto-summary 2>/dev/null || true",
+            marker: REMEMORA_SESSION_END_MARKER,
+            command: "bash ~/.rememora/hooks/session-end.sh 2>/dev/null || true",
         },
         HookSpec {
             event: "Stop",
             marker: REMEMORA_CURATE_MARKER,
-            command: "bash -c '(rememora curate --auto 2>/dev/null || true) &'",
+            command: "bash ~/.rememora/hooks/stop-curate.sh 2>/dev/null || true",
         },
     ]
 }
@@ -78,11 +105,14 @@ fn rememora_hooks() -> &'static [HookSpec] {
 ///
 /// Keep this in sync with the markers used by `rememora_hooks()` plus any
 /// historical command fragments we know we shipped (e.g. `rememora session`).
+/// The `.rememora/hooks/` token catches the new deployed-script form added
+/// in #111.
 const REMEMORA_COMMAND_TOKENS: &[&str] = &[
     "rememora context",
     "rememora search",
     "rememora session",
     "rememora curate",
+    ".rememora/hooks/",
 ];
 
 fn is_rememora_command(cmd: &str) -> bool {
@@ -239,6 +269,53 @@ struct AgentConfig {
 
 fn home() -> PathBuf {
     dirs::home_dir().expect("Could not determine home directory")
+}
+
+/// Directory under which `setup --apply` deploys the bundled plugin hook
+/// scripts. Tracks `REMEMORA_DB` (mirrors `crypto::default_key_file_path`)
+/// so integration tests pointed at a scratch DB do not stomp the user's
+/// real `~/.rememora/hooks/`.
+pub fn default_hooks_dir() -> PathBuf {
+    if let Ok(p) = std::env::var("REMEMORA_DB") {
+        let db = PathBuf::from(p);
+        if let Some(parent) = db.parent() {
+            return parent.join("hooks");
+        }
+    }
+    home().join(".rememora").join("hooks")
+}
+
+/// Write every bundled plugin hook script to `dir/<name>.sh` with mode 0755.
+/// Overwrites existing files so the deployed copy stays in lockstep with the
+/// CLI binary on every `setup --apply` (issue #111).
+fn deploy_hook_scripts(dir: &std::path::Path) -> Result<()> {
+    std::fs::create_dir_all(dir)
+        .with_context(|| format!("Failed to create hooks dir {}", dir.display()))?;
+    for (name, body) in BUNDLED_HOOK_SCRIPTS {
+        let target = dir.join(name);
+        std::fs::write(&target, body)
+            .with_context(|| format!("Failed to write {}", target.display()))?;
+        set_executable(&target).with_context(|| {
+            format!("Failed to set 0755 perms on {}", target.display())
+        })?;
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_executable(path: &std::path::Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = std::fs::metadata(path)?.permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(path, perms)?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn set_executable(_path: &std::path::Path) -> Result<()> {
+    // Non-Unix: shells launched from Claude Code on Windows run via WSL/bash
+    // anyway; the executable bit is irrelevant to `bash <path>`.
+    Ok(())
 }
 
 fn detect_agents() -> Vec<AgentConfig> {
@@ -550,6 +627,18 @@ pub fn run(apply: bool) -> Result<()> {
         return Ok(());
     }
 
+    // Deploy bundled plugin hook scripts to `~/.rememora/hooks/` BEFORE we
+    // mutate any agent's settings.json, so that the moment the new inline
+    // commands point at those scripts, the scripts are already in place
+    // (issue #111). Idempotent — overwrites the existing files so the
+    // scripts upgrade in lockstep with the CLI binary.
+    let hooks_dir = default_hooks_dir();
+    deploy_hook_scripts(&hooks_dir)?;
+    cliclack::log::success(format!(
+        "Deployed hook scripts to {}",
+        tilde_path(&hooks_dir),
+    ))?;
+
     // Apply changes
     for (agent, action) in &actions {
         let (needs_instructions, needs_hooks) = match action {
@@ -640,14 +729,17 @@ fn setup_encryption() -> Result<()> {
 
     match rememora::crypto::persist_key(&key)? {
         rememora::crypto::KeyStorageOutcome::Keychain => {
-            cliclack::log::success("Encryption: key generated and stored in OS keychain")?;
+            // Round-trip readback already verified the value persisted
+            // (issue #109). Safe to claim keychain success.
+            cliclack::log::success("Encryption key stored in OS keychain")?;
         }
-        rememora::crypto::KeyStorageOutcome::File { path, keychain_error } => {
+        rememora::crypto::KeyStorageOutcome::File { path, keychain_error: _ } => {
             // Surface the trade-off explicitly — the file fallback is fine for
             // CI / Docker / vanilla Linux but is weaker than a keychain entry.
+            // The exact `keychain_error` is intentionally elided from the
+            // user-facing message; it stays in code paths/logs for debugging.
             cliclack::log::warning(format!(
-                "Encryption: keychain unavailable ({keychain_error}).\n\
-                 Key written to {} (mode 600).\n\
+                "Encryption: keychain unavailable. Key written to {} (mode 600).\n\
                  For stronger protection, install libsecret-1-0 (or equivalent)\n\
                  and re-run `rememora setup`.",
                 tilde_path(&path),
@@ -989,5 +1081,105 @@ mod tests {
                 .unwrap_or(false)
         });
         assert!(preserved, "user-managed non-rememora hook was clobbered");
+    }
+
+    /// Issue #111: bundled plugin scripts must land on disk under the hooks
+    /// dir with mode 0755 and contain the recursion-gate telemetry calls
+    /// (`rememora debug record-hook-event`) that populate `hook_invocations`.
+    /// Without this, Homebrew/cargo installs get zero observability — the
+    /// inline `(rememora curate --auto) &` form never emitted hook events.
+    #[test]
+    fn deploy_hook_scripts_writes_executable_files_with_telemetry() {
+        let dir = tempfile::tempdir().unwrap();
+        deploy_hook_scripts(dir.path()).expect("deploy_hook_scripts");
+
+        let expected = [
+            "session-start.sh",
+            "session-end.sh",
+            "stop-curate.sh",
+            "prompt-search.sh",
+        ];
+        for name in expected {
+            let p = dir.path().join(name);
+            assert!(p.exists(), "{} must be deployed", name);
+
+            // Mode 0755 on Unix.
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let mode = std::fs::metadata(&p).unwrap().permissions().mode() & 0o777;
+                assert_eq!(mode, 0o755, "{} must be 0755, got 0o{:o}", name, mode);
+            }
+
+            // Sanity: file is non-empty and has a bash shebang.
+            let body = std::fs::read_to_string(&p).unwrap();
+            assert!(
+                body.starts_with("#!/usr/bin/env bash"),
+                "{} missing bash shebang",
+                name,
+            );
+        }
+
+        // The Stop-hook recursion gate is the entire reason #111 exists:
+        // verify the deployed copy still contains the `record-hook-event`
+        // telemetry call so `hook_invocations` will populate when it runs.
+        let stop_curate = std::fs::read_to_string(dir.path().join("stop-curate.sh")).unwrap();
+        assert!(
+            stop_curate.contains("rememora debug record-hook-event"),
+            "stop-curate.sh must call `rememora debug record-hook-event` so \
+             hook_invocations populates for Homebrew/cargo installs (#111)",
+        );
+    }
+
+    /// `deploy_hook_scripts` must be idempotent — running it twice is a
+    /// no-error overwrite (the issue spec calls for re-deploy on every
+    /// `setup --apply` so scripts upgrade in lockstep with the CLI binary).
+    #[test]
+    fn deploy_hook_scripts_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        deploy_hook_scripts(dir.path()).expect("first deploy");
+        // Tamper with one script to simulate a stale version on disk.
+        let stop = dir.path().join("stop-curate.sh");
+        std::fs::write(&stop, "#!/usr/bin/env bash\n# stale\n").unwrap();
+        // Second deploy must overwrite it.
+        deploy_hook_scripts(dir.path()).expect("second deploy");
+        let body = std::fs::read_to_string(&stop).unwrap();
+        assert!(
+            body.contains("rememora debug record-hook-event"),
+            "second deploy did not overwrite stale stop-curate.sh",
+        );
+    }
+
+    /// Issue #111: settings.json's inline commands must reference the
+    /// deployed-script paths under `~/.rememora/hooks/`. Without this, the
+    /// `_emit` recursion-gate telemetry inside the scripts never runs and
+    /// `hook_invocations` stays empty for CLI installs.
+    #[test]
+    fn write_hooks_references_deployed_script_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        write_hooks(&path).unwrap();
+
+        let parsed: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        let hooks = parsed.get("hooks").and_then(|v| v.as_object()).unwrap();
+
+        let cases = [
+            ("SessionStart", "~/.rememora/hooks/session-start.sh"),
+            ("SessionEnd", "~/.rememora/hooks/session-end.sh"),
+            ("Stop", "~/.rememora/hooks/stop-curate.sh"),
+            ("UserPromptSubmit", "~/.rememora/hooks/prompt-search.sh"),
+        ];
+        for (event, expected_path) in cases {
+            let arr = hooks.get(event).and_then(|v| v.as_array()).unwrap();
+            let cmds = collect_envelope_commands(arr);
+            assert!(
+                cmds.iter().any(|c| c.contains(expected_path)),
+                "{} command must reference {} (got: {:?})",
+                event,
+                expected_path,
+                cmds,
+            );
+        }
     }
 }

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -49,9 +49,73 @@ pub enum KeyStorageOutcome {
 /// last line of defence — if it cannot be written, the caller MUST treat
 /// setup as failed and not pretend success (issue #100).
 pub fn persist_key(key: &str) -> Result<KeyStorageOutcome> {
+    persist_key_with(key, keychain_set, keychain_get)
+}
+
+/// Round-trip readback verification for keychain persistence (issue #109).
+///
+/// On Debian-slim and other Linuxes without `libsecret-1-0` / `secret-tool`,
+/// the `keyring` crate's mock backend has been observed to return `Ok(())`
+/// from `set_password` while the value is never actually persisted. Trusting
+/// that silent success leaves the user with an "encryption configured" log
+/// line, no keychain entry, and no file fallback — every later call then
+/// fails to find the key.
+///
+/// The cure is to read the key back immediately after writing it. If the
+/// readback returns `None`, an empty string, or a different value than the
+/// one we just wrote, we treat the keychain as unavailable and fall through
+/// to the file fallback. The `REMEMORA_TEST_NO_KEYCHAIN=1` env var continues
+/// to short-circuit straight to the file path for tests that don't want to
+/// touch the host keychain at all.
+///
+/// `setter` and `getter` are injected so unit tests can exercise the
+/// silent-success failure mode without needing a real keychain.
+fn persist_key_with(
+    key: &str,
+    setter: fn(&str) -> Result<()>,
+    getter: fn() -> Result<Option<String>>,
+) -> Result<KeyStorageOutcome> {
     if std::env::var("REMEMORA_TEST_NO_KEYCHAIN").ok().as_deref() != Some("1") {
-        match keychain_set(key) {
-            Ok(()) => return Ok(KeyStorageOutcome::Keychain),
+        match setter(key) {
+            Ok(()) => match getter() {
+                // Round-trip succeeded — value matches what we wrote.
+                Ok(Some(stored)) if stored == key => return Ok(KeyStorageOutcome::Keychain),
+                // Silent-success path (issue #109): set returned Ok but the
+                // backend either dropped the value (None / empty) or stored
+                // something different. Treat as keychain-unavailable and
+                // fall through to the file tier.
+                Ok(other) => {
+                    let detail = match other {
+                        Some(s) if s.is_empty() => {
+                            "keychain readback returned empty value".to_string()
+                        }
+                        Some(_) => "keychain readback returned a different value".to_string(),
+                        None => "keychain readback returned no entry".to_string(),
+                    };
+                    let path = default_key_file_path();
+                    write_key_file(&path, key).with_context(|| {
+                        format!(
+                            "{detail} and file fallback at {} also failed",
+                            path.display(),
+                        )
+                    })?;
+                    return Ok(KeyStorageOutcome::File {
+                        path,
+                        keychain_error: detail,
+                    });
+                }
+                Err(e) => {
+                    let detail = format!("keychain readback failed: {e:#}");
+                    let path = default_key_file_path();
+                    write_key_file(&path, key).with_context(|| {
+                        format!("{detail} and file fallback at {} also failed", path.display())
+                    })?;
+                    return Ok(KeyStorageOutcome::File {
+                        path,
+                        keychain_error: detail,
+                    });
+                }
+            },
             Err(e) => {
                 let kc_err = format!("{e:#}");
                 let path = default_key_file_path();
@@ -323,6 +387,104 @@ mod tests {
         }
 
         assert_eq!(resolved.as_deref(), Some("file-key-sentinel-for-tests"));
+    }
+
+    /// Issue #109 silent-success regression guard: when the keychain `set`
+    /// returns Ok but the readback returns `None` (the failure mode observed
+    /// on Debian-slim without libsecret), `persist_key_with` must fall back
+    /// to writing the key file rather than reporting Keychain success.
+    #[test]
+    fn persist_key_with_falls_back_when_readback_returns_none() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("rememora.db");
+        let prev_no_kc = std::env::var("REMEMORA_TEST_NO_KEYCHAIN").ok();
+        let prev_db = std::env::var("REMEMORA_DB").ok();
+        std::env::remove_var("REMEMORA_TEST_NO_KEYCHAIN");
+        std::env::set_var("REMEMORA_DB", &db_path);
+
+        // Setter "succeeds" but getter sees no entry — exactly the silent
+        // success the keyring crate exhibits on Linux without libsecret.
+        fn fake_set_ok(_k: &str) -> Result<()> { Ok(()) }
+        fn fake_get_none() -> Result<Option<String>> { Ok(None) }
+
+        let outcome = persist_key_with("rt-test-key", fake_set_ok, fake_get_none)
+            .expect("persist_key_with should not error when fallback succeeds");
+
+        // Restore env before assertions so failures don't leak to siblings.
+        match prev_no_kc {
+            Some(v) => std::env::set_var("REMEMORA_TEST_NO_KEYCHAIN", v),
+            None => std::env::remove_var("REMEMORA_TEST_NO_KEYCHAIN"),
+        }
+        match prev_db {
+            Some(v) => std::env::set_var("REMEMORA_DB", v),
+            None => std::env::remove_var("REMEMORA_DB"),
+        }
+
+        match outcome {
+            KeyStorageOutcome::File { path, keychain_error } => {
+                assert!(
+                    path.starts_with(dir.path()),
+                    "fallback wrote outside scratch dir: {}",
+                    path.display(),
+                );
+                assert!(path.exists(), "fallback file must exist on disk");
+                assert!(
+                    keychain_error.contains("readback") || keychain_error.contains("no entry"),
+                    "keychain_error should describe readback failure, got: {keychain_error}",
+                );
+            }
+            KeyStorageOutcome::Keychain => {
+                panic!("must not report Keychain success when readback returns None");
+            }
+        }
+    }
+
+    /// Round-trip success path: setter writes the key, getter returns it
+    /// unchanged. `persist_key_with` must report `Keychain` and not write
+    /// any file fallback.
+    #[test]
+    fn persist_key_with_uses_keychain_when_readback_matches() {
+        use std::sync::Mutex;
+        static SLOT: Mutex<Option<String>> = Mutex::new(None);
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("rememora.db");
+        let prev_no_kc = std::env::var("REMEMORA_TEST_NO_KEYCHAIN").ok();
+        let prev_db = std::env::var("REMEMORA_DB").ok();
+        std::env::remove_var("REMEMORA_TEST_NO_KEYCHAIN");
+        std::env::set_var("REMEMORA_DB", &db_path);
+
+        fn fake_set(k: &str) -> Result<()> {
+            *SLOT.lock().unwrap() = Some(k.to_string());
+            Ok(())
+        }
+        fn fake_get() -> Result<Option<String>> {
+            Ok(SLOT.lock().unwrap().clone())
+        }
+
+        let outcome = persist_key_with("happy-path-key", fake_set, fake_get)
+            .expect("persist_key_with on success path");
+
+        // Restore env first.
+        match prev_no_kc {
+            Some(v) => std::env::set_var("REMEMORA_TEST_NO_KEYCHAIN", v),
+            None => std::env::remove_var("REMEMORA_TEST_NO_KEYCHAIN"),
+        }
+        match prev_db {
+            Some(v) => std::env::set_var("REMEMORA_DB", v),
+            None => std::env::remove_var("REMEMORA_DB"),
+        }
+
+        assert!(
+            matches!(outcome, KeyStorageOutcome::Keychain),
+            "should report Keychain when readback matches",
+        );
+        // No file should have been written next to the scratch DB.
+        let key_file = dir.path().join("key");
+        assert!(
+            !key_file.exists(),
+            "must not write file fallback when keychain round-trip succeeds",
+        );
     }
 
     /// `default_key_file_path` must place the key file next to the DB when

--- a/tests/test_setup.rs
+++ b/tests/test_setup.rs
@@ -165,7 +165,9 @@ fn setup_apply_no_keychain_creates_db_key_and_hooks() {
     );
 
     // Spot-check the UserPromptSubmit command shape: it must shell out to
-    // `rememora search` so PR #87's FTS5-injection behavior is wired.
+    // the deployed `prompt-search.sh` (issue #111). The script — bundled
+    // via `include_str!` and redeployed on every `setup --apply` — is what
+    // calls `rememora search` and emits the FTS5-injected hits PR #87 added.
     let ups = hooks
         .get("UserPromptSubmit")
         .and_then(|v| v.as_array())
@@ -174,15 +176,15 @@ fn setup_apply_no_keychain_creates_db_key_and_hooks() {
         .get("hooks")
         .and_then(|h| h.as_array())
         .expect("UserPromptSubmit envelope missing inner hooks");
-    let has_search = ups_inner.iter().any(|h| {
+    let has_deployed_script = ups_inner.iter().any(|h| {
         h.get("command")
             .and_then(|c| c.as_str())
-            .map(|s| s.contains("rememora search"))
+            .map(|s| s.contains(".rememora/hooks/prompt-search.sh"))
             .unwrap_or(false)
     });
     assert!(
-        has_search,
-        "UserPromptSubmit hook does not invoke `rememora search`: {:?}",
+        has_deployed_script,
+        "UserPromptSubmit hook does not reference deployed prompt-search.sh: {:?}",
         ups,
     );
 
@@ -204,6 +206,33 @@ fn setup_apply_no_keychain_creates_db_key_and_hooks() {
         "UserPromptSubmit command failed bash -n: {}\ncmd was: {}",
         String::from_utf8_lossy(&parse.stderr),
         cmd,
+    );
+
+    // 4. Issue #111: bundled plugin scripts must be deployed under
+    //    <REMEMORA_DB parent>/hooks/ (i.e. ~/.rememora/hooks/ in production)
+    //    with mode 0755, and the Stop-hook script must contain the
+    //    `record-hook-event` telemetry calls that populate `hook_invocations`.
+    let hooks_dir = home_path.join(".rememora").join("hooks");
+    for name in ["session-start.sh", "session-end.sh", "stop-curate.sh", "prompt-search.sh"] {
+        let p = hooks_dir.join(name);
+        assert!(p.exists(), "{} not deployed at {}", name, p.display());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&p).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o755, "{} perms 0o{:o} != 0o755", name, mode);
+        }
+    }
+    let stop_curate = std::fs::read_to_string(hooks_dir.join("stop-curate.sh")).unwrap();
+    assert!(
+        stop_curate.contains("rememora debug record-hook-event"),
+        "deployed stop-curate.sh missing record-hook-event telemetry — \
+         hook_invocations will not populate for CLI installs (#111)",
+    );
+    let prompt_search = std::fs::read_to_string(hooks_dir.join("prompt-search.sh")).unwrap();
+    assert!(
+        prompt_search.contains("rememora search"),
+        "deployed prompt-search.sh missing `rememora search` invocation",
     );
 }
 


### PR DESCRIPTION
Iter 4 of the docker sandbox fix loop. Bundles three issues into one PR.

## Closes
- #109 — keychain silent-success on Linux without libsecret (HIGH)
- #110 — .claude.json warning in docker sandbox (LOW, cosmetic)
- #111 — hook_invocations not populated for setup --apply users (MEDIUM)

---

## #109 — keychain silent-success → readback verify

**Before:** on Debian-slim and similar hosts without `libsecret-1-0`, `keyring::Entry::set_password` returns `Ok(())` while the value is never actually stored. PR #102's `REMEMORA_TEST_NO_KEYCHAIN=1` only flipped the fallback path for tests; production code still trusted the silent success. Net effect: setup printed "key stored in keychain" and the user's `~/.rememora/` was empty afterward — every later CLI call failed.

**After:** `persist_key` now does a round-trip readback. Immediately after `keychain_set`, it calls `keychain_get` and verifies the value matches. `None` / empty / mismatch all fall through to the existing 0600 file fallback. The function-pointer plumbing (`persist_key_with`) lets unit tests simulate the silent-success failure mode without touching a real keychain.

User-facing strings updated per the issue spec:
- Round-trip succeeds → `Encryption key stored in OS keychain`
- Round-trip fails or env var is set → `Encryption: keychain unavailable. Key written to ~/.rememora/key (mode 600). For stronger protection, install libsecret-1-0 (or equivalent) and re-run rememora setup.`

## #110 — .claude.json warning in docker sandbox

**Before:** `claude -p` inside the sandbox prints `Claude configuration file not found at: ~/.claude.json` 3+ times per invocation. Cosmetic but loud.

**After:** `docker/entrypoint.sh` seeds `/home/tester/.claude.json` with `{}` (idempotent) before sshd starts. If the user later runs `/login`, Claude Code overwrites the placeholder on first real write. No CLI changes.

## #111 — bundle plugin hook scripts; deploy on setup --apply

**Before:** `setup --apply` wrote inline commands like `bash -c '(rememora curate --auto) &'` directly into `~/.claude/settings.json`. The plugin tree's `stop-curate.sh` — which contains the `rememora debug record-hook-event` calls that populate `hook_invocations` (#82) — was only present for marketplace installs. Homebrew/cargo users got zero recursion-gate observability, defeating the point of #82 for half the install base.

**After:** the four canonical hook scripts are bundled into the binary via `include_str!`:
- `plugin/scripts/session-start.sh`
- `plugin/scripts/session-end.sh`
- `plugin/scripts/stop-curate.sh`
- `plugin/scripts/prompt-search.sh`

Every `setup --apply` deploys them to `~/.rememora/hooks/<name>.sh` (mode 0755, overwrites — scripts upgrade in lockstep with the CLI). The settings.json inline commands now reference the deployed paths via `bash ~/.rememora/hooks/<name>.sh 2>/dev/null || true`. Tilde expansion is shell-side; Claude Code launches hooks via bash so this resolves correctly without us having to bake an absolute per-host path.

`default_hooks_dir()` tracks `REMEMORA_DB` (mirrors `crypto::default_key_file_path`) so integration tests against scratch DBs do not stomp the user's real `~/.rememora/hooks/`.

Marker fingerprints in `rememora_hooks()` updated to reference the new deployed-script form; old command tokens stay in `REMEMORA_COMMAND_TOKENS` so the migration path continues to heal pre-fix flat-shape entries (issue #107 regression coverage preserved).

---

## Tests

- `crypto::persist_key_with_falls_back_when_readback_returns_none` — exact silent-success simulation
- `crypto::persist_key_with_uses_keychain_when_readback_matches` — happy path
- `setup::deploy_hook_scripts_writes_executable_files_with_telemetry` — verifies 0755 + `record-hook-event` present
- `setup::deploy_hook_scripts_is_idempotent` — second deploy overwrites stale copies
- `setup::write_hooks_references_deployed_script_paths` — settings.json points at `~/.rememora/hooks/`
- `tests/test_setup.rs::setup_apply_no_keychain_creates_db_key_and_hooks` — extended to assert deployed scripts on disk and telemetry present

`cargo test` and `cargo clippy --lib --bins -- -D warnings` both clean.

## Test plan

- [ ] CI: `cargo test` and `cargo clippy --all-targets`
- [ ] Manual: rebuild docker sandbox, run `rememora setup --apply` inside it, verify:
  - `~/.rememora/hooks/*.sh` exist with mode 0755
  - `~/.claude/settings.json` references those paths
  - `claude -p "hi"` does not print the `.claude.json` warning anymore
  - After running a Claude Code session, `rememora debug ...` shows rows in `hook_invocations`
- [ ] Manual: on macOS host with keychain available, run setup and confirm key is stored in OS keychain (round-trip readback exercised end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)