### PR TITLE
fix(setup,session): #113 missing-key recovery + #114 SessionEnd in -p + #115 hook redeploy

### DIFF
--- a/plugin/scripts/session-end.sh
+++ b/plugin/scripts/session-end.sh
@@ -17,7 +17,22 @@ INPUT=$(cat)
 CWD=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('cwd',''))" 2>/dev/null || echo "")
 SESSION_ID=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('session_id',''))" 2>/dev/null || echo "")
 
-rememora session end-active --auto-summary 2>/dev/null || true
+# Pass the same project name session-start.sh used (basename of cwd). Without
+# this, `end-active` falls back to `detect_from_cwd` which only resolves
+# *registered* projects — running `claude -p` from `/tmp/<scratch>` (CI,
+# agent-loop, ad-hoc) would silently no-op and leak active session rows
+# forever (issue #114). The CLI also gained a basename-fallback so older
+# hooks keep working, but this explicit form is the canonical one.
+PROJECT_FOR_END=""
+if [ -n "$CWD" ]; then
+  PROJECT_FOR_END=$(basename "$CWD")
+fi
+
+if [ -n "$PROJECT_FOR_END" ]; then
+  rememora session end-active --project "$PROJECT_FOR_END" --auto-summary 2>/dev/null || true
+else
+  rememora session end-active --auto-summary 2>/dev/null || true
+fi
 
 if [ -n "$CWD" ] && [ -n "$SESSION_ID" ]; then
   ENCODED_CWD=$(echo "$CWD" | sed 's|/|-|g')

--- a/src/commands/session.rs
+++ b/src/commands/session.rs
@@ -50,12 +50,26 @@ pub fn end_active(
     auto_summary: bool,
     json: bool,
 ) -> Result<()> {
-    // Resolve project: explicit flag or auto-detect from CWD
+    // Resolve project: explicit flag, then registered-project lookup by cwd,
+    // then basename(cwd) — the same string `session start` uses when called
+    // from a hook in an unregistered directory.
+    //
+    // Issue #114: previously this stopped at `detect_from_cwd`, which only
+    // returns Some when a project's registered `path` is a prefix of cwd.
+    // Running `claude -p` from `/tmp/<scratch>` (CI, agent-loop, ad-hoc)
+    // would no-op silently and leak `[active]` session rows.
     let resolved_project = if let Some(p) = project {
         Some(p.to_string())
     } else {
         let cwd = std::env::current_dir()?;
-        project::detect_from_cwd(conn, cwd.to_str().unwrap_or(""))?
+        let cwd_str = cwd.to_str().unwrap_or("");
+        match project::detect_from_cwd(conn, cwd_str)? {
+            Some(p) => Some(p),
+            None => cwd
+                .file_name()
+                .and_then(|n| n.to_str())
+                .map(|s| s.to_string()),
+        }
     };
 
     let project_name = match resolved_project {

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -696,9 +696,57 @@ pub fn run(apply: bool) -> Result<()> {
 fn setup_encryption() -> Result<()> {
     let db_path = rememora::db::default_db_path();
 
-    // Already encrypted — nothing to do beyond making sure the DB is reachable.
+    // Already encrypted — confirm we can still open it before claiming success.
+    //
+    // Issue #113: previously we returned Ok immediately on `is_db_encrypted`,
+    // even if every key source (env / file / keychain) was empty. Setup would
+    // print "already configured" and exit green while every subsequent
+    // `rememora` call errored on a no-tty key prompt. Now we also probe the
+    // key chain via `resolve_key_no_prompt` and, if no key is reachable, fall
+    // through to a recovery branch that re-runs the persist path (or surfaces
+    // a clear error in non-interactive environments).
     if db_path.exists() && rememora::crypto::is_db_encrypted(&db_path) {
-        cliclack::log::success("Encryption: already enabled")?;
+        if rememora::crypto::resolve_key_no_prompt()?.is_some() {
+            cliclack::log::success("Encryption: already enabled")?;
+            return Ok(());
+        }
+
+        cliclack::log::warning(
+            "Database is encrypted but no key is reachable in env, file, or keychain.\n\
+             Paste your existing encryption key to restore access (or Ctrl-C to abort).",
+        )?;
+        let key = cliclack::password("Encryption key:")
+            .interact()
+            .context(
+                "Cannot prompt for key in non-interactive setup. \
+                 Set REMEMORA_KEY, restore ~/.rememora/key, or run `rememora decrypt` to recover.",
+            )?;
+        if key.trim().is_empty() {
+            anyhow::bail!(
+                "Empty key provided; cannot recover encrypted database. \
+                 Restore the original key file or use `rememora decrypt` if you have a backup."
+            );
+        }
+
+        // Verify the key actually opens the DB before persisting it — otherwise
+        // we'd happily store a wrong value and break every subsequent run.
+        std::env::set_var("REMEMORA_KEY", key.trim());
+        rememora::db::open(&db_path).context(
+            "Provided key did not open the database. \
+             Check for typos or restore from a known-good source.",
+        )?;
+
+        match rememora::crypto::persist_key(key.trim())? {
+            rememora::crypto::KeyStorageOutcome::Keychain => {
+                cliclack::log::success("Encryption key restored to OS keychain")?;
+            }
+            rememora::crypto::KeyStorageOutcome::File { path, .. } => {
+                cliclack::log::success(format!(
+                    "Encryption key restored to {} (mode 600)",
+                    tilde_path(&path),
+                ))?;
+            }
+        }
         return Ok(());
     }
 

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -604,6 +604,22 @@ pub fn run(apply: bool) -> Result<()> {
         .filter(|(_, a)| !matches!(a, Action::AlreadyConfigured))
         .collect();
 
+    // Deploy bundled plugin hook scripts to `~/.rememora/hooks/` BEFORE the
+    // "already configured" early-return — otherwise users who upgrade the
+    // rememora CLI (Homebrew, cargo install, marketplace plugin) would end up
+    // running the *old* shell scripts indefinitely, since their settings.json
+    // already points at canonical hook paths and the old per-agent action is
+    // `AlreadyConfigured` (issue #115). `deploy_hook_scripts` is idempotent
+    // (overwrites in place) so it's safe to run on every `--apply`.
+    let hooks_dir = default_hooks_dir();
+    if apply {
+        deploy_hook_scripts(&hooks_dir)?;
+        cliclack::log::success(format!(
+            "Deployed hook scripts to {}",
+            tilde_path(&hooks_dir),
+        ))?;
+    }
+
     if pending.is_empty() {
         cliclack::outro("All agents already configured.")?;
         return Ok(());
@@ -626,18 +642,6 @@ pub fn run(apply: bool) -> Result<()> {
         cliclack::outro("Setup cancelled.")?;
         return Ok(());
     }
-
-    // Deploy bundled plugin hook scripts to `~/.rememora/hooks/` BEFORE we
-    // mutate any agent's settings.json, so that the moment the new inline
-    // commands point at those scripts, the scripts are already in place
-    // (issue #111). Idempotent — overwrites the existing files so the
-    // scripts upgrade in lockstep with the CLI binary.
-    let hooks_dir = default_hooks_dir();
-    deploy_hook_scripts(&hooks_dir)?;
-    cliclack::log::success(format!(
-        "Deployed hook scripts to {}",
-        tilde_path(&hooks_dir),
-    ))?;
 
     // Apply changes
     for (agent, action) in &actions {

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -331,15 +331,24 @@ fn prompt_for_key(prompt: &str) -> Result<String> {
 mod tests {
     use super::*;
 
+    /// Cargo runs unit tests in this module concurrently by default. Several
+    /// tests below mutate `REMEMORA_KEY` / `REMEMORA_DB` / `REMEMORA_TEST_NO_KEYCHAIN`
+    /// and call code paths (`default_key_file_path`, `resolve_key_no_prompt`,
+    /// `persist_key_with`) that read those vars. Without serialization, two
+    /// tests can stomp each other: A sets `REMEMORA_DB=tmpA`, B overwrites it
+    /// with `tmpB`, A then writes its key file under `tmpB` and the assertion
+    /// `path.starts_with(tmpA)` fails. Acquire this guard at the top of any
+    /// env-touching test.
+    static ENV_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     /// `resolve_key_no_prompt` must return the env var when it is set, without
     /// touching the keychain. This is the path GUI callers (the desktop app)
     /// rely on to stay non-interactive.
     #[test]
     fn resolve_key_no_prompt_reads_env_var() {
+        let _guard = ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
         // Use a unique value so we do not collide with any real developer env.
         let sentinel = "env-key-sentinel-for-tests";
-        // Safety: tests in this crate do not run concurrently against the same
-        // env var name; `cargo test` serialises within a process per test fn.
         std::env::set_var("REMEMORA_KEY", sentinel);
         let result = resolve_key_no_prompt().expect("resolve_key_no_prompt");
         std::env::remove_var("REMEMORA_KEY");
@@ -353,6 +362,7 @@ mod tests {
     /// (issue #100).
     #[test]
     fn resolve_key_no_prompt_reads_file_when_env_unset() {
+        let _guard = ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
         let dir = tempfile::tempdir().expect("tempdir");
         let db_path = dir.path().join("rememora.db");
         let key_path = dir.path().join("key");
@@ -395,6 +405,7 @@ mod tests {
     /// to writing the key file rather than reporting Keychain success.
     #[test]
     fn persist_key_with_falls_back_when_readback_returns_none() {
+        let _guard = ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
         let dir = tempfile::tempdir().expect("tempdir");
         let db_path = dir.path().join("rememora.db");
         let prev_no_kc = std::env::var("REMEMORA_TEST_NO_KEYCHAIN").ok();
@@ -444,6 +455,7 @@ mod tests {
     /// any file fallback.
     #[test]
     fn persist_key_with_uses_keychain_when_readback_matches() {
+        let _guard = ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
         use std::sync::Mutex;
         static SLOT: Mutex<Option<String>> = Mutex::new(None);
 
@@ -492,6 +504,7 @@ mod tests {
     /// callers from polluting the user's `~/.rememora/`.
     #[test]
     fn default_key_file_path_tracks_remora_db_env() {
+        let _guard = ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
         let prev = std::env::var("REMEMORA_DB").ok();
         std::env::set_var("REMEMORA_DB", "/tmp/rememora-key-path-test/scratch.db");
         let p = default_key_file_path();


### PR DESCRIPTION
## Summary

Three independent setup/session bugs surfaced during iter 4 + iter 5 of the Docker sandbox validation loop, all bundled here because they share the same setup/upgrade flow.

- **#113** — `setup --apply` falsely reported "already configured" when the encrypted DB existed but no key was reachable in env/file/keychain (e.g., key file deleted, fresh container with detached volume). Subsequent `rememora` calls all errored on a no-tty key prompt. Now setup probes the key chain via `resolve_key_no_prompt`, prompts for the key when reachable interactively (round-tripping it through `db::open` before persisting), and surfaces a clear recovery message in non-interactive environments.

- **#114** — `claude -p` exits leaked `[active]` session rows forever. Empirically verified that SessionEnd hook *does* fire in `-p` mode (Claude Code emits `reason: "other"`); the bug was that the hook called `rememora session end-active --auto-summary` without `--project`, and `detect_from_cwd` returned None for unregistered scratch dirs (e.g., `/tmp/<dir>`, agent-loop work areas). Fixed in two layers: `end_active` falls back to `basename(cwd)` when no registered project matches (mirroring what `session start` does implicitly), AND `session-end.sh` now passes `--project "$(basename $CWD)"` explicitly so the resolution isn't sole-dependent on the CLI fallback.

- **#115** — `setup --apply` skipped `deploy_hook_scripts` when every agent was already configured, leaving users on stale bundled hook scripts after every CLI upgrade. `deploy_hook_scripts` is idempotent (overwrites in place) so it now runs unconditionally on `--apply`, before the early-return.

## Test plan

- [x] `cargo test --test test_setup` — both existing setup integration tests pass
- [x] `cargo test --lib` — 77 passing
- [x] **Sandbox iter 5** end-to-end:
  - [x] `rememora setup --apply` with key file deleted → errors with clear recovery message in non-interactive env (#113)
  - [x] `rememora setup --apply` after upgrade prints "Deployed hook scripts to ~/.rememora/hooks" even when settings.json is unchanged (#115)
  - [x] `claude -p "Reply with one word: BLAH"` from `/tmp/iter5b` (unregistered cwd) → `rememora session list` shows the new session as `[ended]` not `[active]` (#114)
  - [x] All 4 hooks (SessionStart, UserPromptSubmit, Stop, SessionEnd) confirmed firing in `-p` mode via debug-logging wrappers
- [ ] Verify on a real macOS host with libsecret-equivalent (Keychain Access)

## Notes

- Pre-existing test `crypto::tests::persist_key_with_falls_back_when_readback_returns_none` is flaky in parallel runs (writes outside scratch dir under contention) — passes on isolated re-run; not introduced by this PR.
- The bundled `session-end.sh` belongs to the marketplace plugin; this also benefits CLI-only installs since `setup --apply` deploys the same bundled scripts via `include_str!` (#111 path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)