### PR TITLE
fix(plugin): honor REMEMORA_CURATE_CHILD in all hooks (#117)

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -37,12 +37,12 @@ If a Rememora hook misbehaves and you need to turn everything off quickly, set t
 export REMEMORA_DISABLE_HOOKS=1
 ```
 
-All three hook scripts (`session-start.sh`, `session-end.sh`, `stop-curate.sh`) check this env var at the top and early-exit 0 when set. `unset REMEMORA_DISABLE_HOOKS` to re-enable.
+All four hook scripts (`session-start.sh`, `session-end.sh`, `stop-curate.sh`, `prompt-search.sh`) check this env var at the top and early-exit 0 when set. `unset REMEMORA_DISABLE_HOOKS` to re-enable.
 
 Other tunables:
 
 - `REMEMORA_CURATE_COOLDOWN_SECS` (default `300`): minimum seconds between curate runs per session. Set to `0` to disable the frequency gate. The kernel-level `pgrep` concurrency gate is independent and always active.
-- `REMEMORA_CURATE_CHILD`: set internally by `rememora curate` on its `claude -p` subprocesses so those children's Stop hooks don't recursively curate. Not intended for user override.
+- `REMEMORA_CURATE_CHILD`: set internally by `rememora curate` on its `claude -p` subprocesses so the entire hook chain is a no-op inside curator children (no spurious session rows, no context injection, no recursive curate). Not intended for user override.
 
 ## How it works
 

--- a/plugin/scripts/prompt-search.sh
+++ b/plugin/scripts/prompt-search.sh
@@ -10,6 +10,11 @@
 # Kill-switch — disables all Rememora hooks.
 [ -n "${REMEMORA_DISABLE_HOOKS:-}" ] && exit 0
 
+# Curator-child gate (issue #117). The signal-detector / AUDN curator prompts
+# are closed-loop rememora plumbing. Prepending FTS5 hits to them just bloats
+# the prompt with content the curator never asked for and cannot use.
+[ -n "${REMEMORA_CURATE_CHILD:-}" ] && exit 0
+
 if ! command -v rememora >/dev/null 2>&1; then
   exit 0
 fi

--- a/plugin/scripts/session-end.sh
+++ b/plugin/scripts/session-end.sh
@@ -7,6 +7,12 @@
 # Kill-switch: set REMEMORA_DISABLE_HOOKS=1 to disable all Rememora hooks.
 [ -n "${REMEMORA_DISABLE_HOOKS:-}" ] && exit 0
 
+# Curator-child gate (issue #117). See session-start.sh for the reasoning;
+# we must not call `session end-active` from inside a curator child or it
+# will close the user's most-recent active session in the middle of their
+# real claude run.
+[ -n "${REMEMORA_CURATE_CHILD:-}" ] && exit 0
+
 set -euo pipefail
 
 if ! command -v rememora &>/dev/null; then

--- a/plugin/scripts/session-start.sh
+++ b/plugin/scripts/session-start.sh
@@ -17,6 +17,16 @@
 # Kill-switch: set REMEMORA_DISABLE_HOOKS=1 to disable all Rememora hooks.
 [ -n "${REMEMORA_DISABLE_HOOKS:-}" ] && exit 0
 
+# Curator-child gate (issue #117). When `rememora curate` spawns `claude -p`
+# for signal detection / AUDN curation, every hook in this directory runs
+# against a transcript the curator already owns. Without an early-exit, each
+# child claude would: create a spurious session row, prepend full project
+# context to its closed-loop signal-detector prompt, and re-run FTS5 search
+# on a transcript that's pure rememora plumbing. The Stop hook had this
+# guard; the other three didn't, producing ~30 leaked sessions per real
+# user turn. The whole hook chain is a no-op inside curator children.
+[ -n "${REMEMORA_CURATE_CHILD:-}" ] && exit 0
+
 set -euo pipefail
 
 # Check if rememora is available


### PR DESCRIPTION
## Summary

Closes #117. Each user `claude -p` turn was creating ~30 session rows because only `stop-curate.sh` honored `REMEMORA_CURATE_CHILD`; the other three plugin hooks (`session-start.sh`, `session-end.sh`, `prompt-search.sh`) ran their full bodies inside curator-spawned children. The fan-out:

- SessionStart inside curator child → spurious `session start` row + full context injected into closed-loop signal-detector prompt
- UserPromptSubmit inside curator child → FTS5 lookups prepended to a transcript the curator already owns
- SessionEnd inside curator child → `session end-active` racing against the user's real session

Add the same one-line gate to all four hooks:

```bash
[ -n "${REMEMORA_CURATE_CHILD:-}" ] && exit 0
```

Curator children are pure rememora plumbing — no user-visible session, no context injection, no recursive curate.

## Sandbox results

| Metric | Iter 6 (before) | Iter 7 (after) |
|---|---|---|
| Session rows / user turn | ~28 (6 → 33 in 60s) | 1 (61 → 62) |
| Back-to-back: 2 turns | n/a | exactly +2 (62 → 64) |
| `passed_through` per real turn | bursty | exactly 1 |
| `env_var_short_circuit` (curator children) | 24 → catching after damage | 53 → catching at the gate |
| Memory recall | ✅ still works | ✅ still works (`ClickHouse` answer correct) |

## Test plan

- [x] `cargo test --lib` — 77 passing
- [x] **Sandbox iter 7** end-to-end: 1 user turn = 1 session row, recall preserved, all 4 hooks honor the gate (`grep REMEMORA_CURATE_CHILD ~/.rememora/hooks/*.sh` shows the early-exit on every script)
- [x] Curator's recursion gate (`stop-curate`) still working — `env_var_short_circuit` count matches expectations
- [ ] Real macOS host with libsecret-equivalent

🤖 Generated with [Claude Code](https://claude.com/claude-code)