### PR TITLE
fix(plugin): skip SessionEnd tail-pass curate when Stop curate is in flight (#121)

### DIFF
--- a/plugin/scripts/session-end.sh
+++ b/plugin/scripts/session-end.sh
@@ -46,21 +46,33 @@ if [ -n "$CWD" ] && [ -n "$SESSION_ID" ]; then
   PROJECT=$(basename "$CWD")
 
   if [ -f "$JSONL_PATH" ]; then
-    # Fully detach the final-pass curate. Plain `&` backgrounds scheduling
-    # but does NOT close inherited file descriptors — a curate subprocess
-    # that lingers past SessionEnd could keep the hook's pipe write-end
-    # open and cause the same FD-leak blocking we fixed in stop-curate.sh.
-    # Apply the same setsid (Linux) / nohup + disown (macOS) detachment and
-    # redirect all three std streams on the outer launch.
-    if command -v setsid >/dev/null 2>&1; then
-      setsid bash -c '
-        rememora curate --file "$1" --project "$2" >/dev/null 2>&1 || true
-      ' _ "$JSONL_PATH" "$PROJECT" </dev/null >/dev/null 2>&1 &
+    # Cross-hook concurrency gate (issue #121). In `claude -p` Stop and
+    # SessionEnd fire back-to-back; both used to spawn curate on the same
+    # transcript, two AUDN agents searched in parallel before either's saves
+    # had committed, and we ended up with near-duplicate memories. Skip the
+    # tail-pass when Stop's curate is still running on this same JSONL —
+    # the in-flight curate already owns the work. The check is best-effort:
+    # `pgrep` may miss a curate that's just spawning, but the worst case is
+    # the same race we had before, just on a much narrower window.
+    if pgrep -f "rememora curate --file ${JSONL_PATH}" >/dev/null 2>&1; then
+      :  # Stop hook's curate is in flight; skip the tail-pass.
     else
-      nohup bash -c '
-        rememora curate --file "$1" --project "$2" >/dev/null 2>&1 || true
-      ' _ "$JSONL_PATH" "$PROJECT" </dev/null >/dev/null 2>&1 &
-      disown
+      # Fully detach the final-pass curate. Plain `&` backgrounds scheduling
+      # but does NOT close inherited file descriptors — a curate subprocess
+      # that lingers past SessionEnd could keep the hook's pipe write-end
+      # open and cause the same FD-leak blocking we fixed in stop-curate.sh.
+      # Apply the same setsid (Linux) / nohup + disown (macOS) detachment and
+      # redirect all three std streams on the outer launch.
+      if command -v setsid >/dev/null 2>&1; then
+        setsid bash -c '
+          rememora curate --file "$1" --project "$2" >/dev/null 2>&1 || true
+        ' _ "$JSONL_PATH" "$PROJECT" </dev/null >/dev/null 2>&1 &
+      else
+        nohup bash -c '
+          rememora curate --file "$1" --project "$2" >/dev/null 2>&1 || true
+        ' _ "$JSONL_PATH" "$PROJECT" </dev/null >/dev/null 2>&1 &
+        disown
+      fi
     fi
   fi
 


### PR DESCRIPTION
## Summary

Closes #121. In `claude -p` mode Stop and SessionEnd fire back-to-back and both spawned `rememora curate` on the same transcript. Two AUDN agents searched in parallel before either's saves committed, producing near-duplicate memories.

Fix: cross-hook `pgrep` gate in `session-end.sh` — if Stop's curate on the same JSONL is still running, the in-flight run already owns the work and the tail-pass skips. In interactive long sessions Stop's curate finishes well before SessionEnd, so the original tail-pass guarantee (catch the last turn even if it landed in cooldown) is preserved.

## Sandbox results

| | Iter 10 (before #121) | Iter 11 (after #121) |
|---|---|---|
| Curator runs / user turn | 2 (Stop + SessionEnd both fire) | 1 (Stop only; SessionEnd skips when Stop is in flight) |
| signal_gate calls | 2 | 1 |
| Memories saved (Kafka conversation) | 7 (with 2 pairs of near-duplicates) | n/a — repro project; clean iter 11 (proj-e payments) → 2 distinct memories |
| Cost / turn | $0.1515 | $0.0691 |
| Memory dedup | post-hoc (visible duplicates in `rememora context`) | preventive (single curator owns the work) |

Iter 11 example (proj-e, single user turn discussing idempotency-key strategy):
- 1× `[decision] Idempotency keys use (merchant_id, request_id) tuples...`
- 1× `[entity] proj-e is a payments service`

## Test plan

- [x] `cargo test --lib` — 80 passing (no regressions; this is a shell-only change)
- [x] **Sandbox iter 11** end-to-end:
  - [x] `pgrep` gate present in deployed `~/.rememora/hooks/session-end.sh`
  - [x] One `claude -p` turn → exactly 1 signal_gate + 1 curator call recorded in `agent_invocations`
  - [x] No near-duplicate memories in `rememora context --project proj-e`
- [ ] Verify in interactive (non-`-p`) long session: SessionEnd's tail-pass should still fire when Stop's per-turn curate has long-since finished

🤖 Generated with [Claude Code](https://claude.com/claude-code)