### PR TITLE
docs: refresh README + rememora.ai for v1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](LICENSE)
 [![Homebrew](https://img.shields.io/badge/brew-Rememora%2Ftap-orange?style=flat-square)](https://github.com/Rememora/homebrew-tap)
 
+> **What's new in v1.5.0** — `rememora update [--check]` surfaces a one-line upgrade hint matched to your install method (Homebrew / cargo / unknown). 1.4.0 and 1.4.1 before it made the autonomous memory pipeline actually work end-to-end on modern Claude Code (the curator parser was inert in 1.2.x — Stop hook fired but no memories were ever saved). Full notes: [v1.5.0](https://github.com/Rememora/rememora/releases/tag/v1.5.0) · [v1.4.1](https://github.com/Rememora/rememora/releases/tag/v1.4.1) · [v1.4.0](https://github.com/Rememora/rememora/releases/tag/v1.4.0) · [CHANGELOG](CHANGELOG.md)
+
 Persistent, cross-agent memory for AI coding agents. One SQLite database, shared by every agent you use.
 
 **The problem:** Claude Code, Codex, and Gemini CLI each lose context between sessions. Switch agents mid-task and you start from scratch. Come back to a project after a week and the agent has forgotten everything.
@@ -50,6 +52,16 @@ cargo install --path .
 # Or download from GitHub Releases
 # https://github.com/Rememora/rememora/releases
 ```
+
+### Staying up to date
+
+```bash
+rememora update                # hits GitHub, prints status + upgrade hint
+rememora update --check        # respect 24h cache (use from scripts/hooks)
+brew upgrade rememora          # actual upgrade (Homebrew)
+```
+
+`rememora update` detects your install method (Homebrew / `cargo install` / unknown) from the running binary's path and prints the appropriate upgrade command — it never auto-executes the upgrade. `rememora setup --apply` also prints the same hint inline when a newer release is cached. Set `REMEMORA_NO_UPDATE_CHECK=1` to disable entirely.
 
 ## Quick Start
 
@@ -179,22 +191,32 @@ claude plugin install rememora@rememora
 claude plugin install rememora@rememora --scope project
 ```
 
-This gives you hooks + skills that work automatically — no manual commands needed:
+This gives you four hooks + three skills that work automatically — no manual commands needed:
 
 | Component | What it does |
 |-----------|-------------|
-| **SessionStart hook** | Loads project context + starts rememora session |
-| **SessionEnd hook** | Closes the active session |
-| **Stop hook** | Curates memories from the session transcript after each turn |
+| **SessionStart hook** | Loads project context (L0 + L1) and opens a tracked session |
+| **UserPromptSubmit hook** | Injects top-3 FTS5 hits matching your prompt into the agent's context |
+| **Stop hook** | Curates memories from the session transcript after each turn (gated) |
+| **SessionEnd hook** | Final-pass curation + closes the active session row |
 | **rememora-save skill** | Claude autonomously saves decisions, bug fixes, patterns |
 | **rememora-search skill** | Claude autonomously searches before implementations |
 | **`/rememora` command** | Manual save, search, or status check |
 
-After installing, restart Claude Code. The plugin auto-detects your project from the working directory.
+After installing, restart Claude Code. The plugin auto-detects your project from the working directory and now ships verified end-to-end on the marketplace install path (sandbox iter 12 confirmed: 3 substantive turns → 7 memories captured autonomously, fresh session recalls all 3 architectural decisions).
+
+**Updating the plugin:**
+
+```bash
+claude plugin marketplace update rememora    # refresh the marketplace cache
+claude plugin update rememora@rememora       # update the plugin (note the @marketplace suffix)
+```
 
 **Configuration:**
 
-- `REMEMORA_CURATE_COOLDOWN_SECS` (default: `300`) — minimum idle seconds between automatic curation runs from the Claude Code `Stop` hook, per session. The Stop hook fires after every agent turn. The plugin enforces **at most one in-flight `rememora curate` per session** via a kernel-level concurrency gate (`pgrep` on the session ID); this setting layers on top as a secondary frequency gate, bounding how long to wait after a curate *finishes* before another is allowed. Set to `0` to disable the cooldown — the concurrency gate still applies. A final curation pass always runs at `SessionEnd` regardless of cooldown, so the tail of the session is never lost.
+- `REMEMORA_CURATE_COOLDOWN_SECS` (default: `300`) — minimum idle seconds between automatic curation runs from the `Stop` hook, per session. The plugin enforces **at most one in-flight `rememora curate` per session** via a kernel-level concurrency gate (`pgrep` on the session ID); this setting layers on top as a secondary frequency gate, bounding how long to wait after a curate *finishes* before another is allowed. Set to `0` to disable the cooldown — the concurrency gate still applies. A final curation pass always runs at `SessionEnd` regardless of cooldown, so the tail of the session is never lost.
+- `REMEMORA_DISABLE_HOOKS=1` — kill-switch for all four hooks. Useful for debugging.
+- `REMEMORA_CURATE_CHILD=1` — set internally by the curator on its `claude -p` subprocesses so the entire hook chain is a no-op inside curator children (no spurious session rows, no context injection, no recursive curation). Not intended for user override.
 
 ### Claude Code (Alternative: CLAUDE.md)
 
@@ -280,8 +302,10 @@ cargo tauri dev
 | `rememora agent-run --repo X --issue N` | Dispatch issue to Claude CLI |
 | `rememora agent-loop --repo X` | Watch board + auto-dispatch |
 | `rememora setup` | Configure agents to use rememora |
+| `rememora update [--check]` | Check GitHub for a newer release; print upgrade hint |
 | `rememora eval` | DB compliance metrics |
 | `rememora status` | Show DB stats |
+| `rememora usage [--hooks]` | Aggregate LLM telemetry (or hook gate-outcomes with `--hooks`) |
 | `rememora export --project <name>` | Export as JSON or markdown |
 
 All commands support `--json` for structured output.
@@ -457,7 +481,7 @@ Results are exported as **Braintrust-aligned JSONL** (`input/output/expected/sco
 ## Development
 
 ```bash
-cargo test          # 124 tests (121 pass, 3 ignored)
+cargo test          # 187 tests (lib + integration)
 cargo build         # Debug build
 cargo clippy        # Lint
 ```
@@ -495,19 +519,23 @@ cargo clippy        # Lint
 
 ## Roadmap
 
-- [x] Auto-extraction of memories from text via LLM
-- [x] Homebrew formula (`brew install Rememora/tap/rememora`)
-- [x] Claude Code hooks for automatic session tracking
-- [x] Autonomous curation from session transcripts
-- [x] Memory consolidation (evolve + consolidate)
-- [x] Agent orchestration (agent-run + agent-loop)
-- [x] Agent auto-setup (detect + configure)
-- [x] Eval benchmark harness (scenarios + long-run + conditions matrix)
-- [x] Cheatsheet context mode (compact top-5 summary)
-- [ ] Vector search via candle + sqlite-vec (hybrid BM25 + cosine similarity)
+- [x] Cross-agent memory + transfer chain
+- [x] Autonomous curation pipeline (signal gate + AUDN curator)
+- [x] Claude Code plugin with 4 hooks (SessionStart, UserPromptSubmit, Stop, SessionEnd)
+- [x] Marketplace install (`claude plugin install rememora@rememora`)
+- [x] Homebrew formula + auto-update notifications (`rememora update`)
 - [x] Hierarchical retrieval with score propagation
-- [ ] Memory evolution — LLM-based consolidation of old memories
+- [x] Memory consolidation (evolve + consolidate, BM25 clustering + LLM)
+- [x] Agent orchestration (agent-run + agent-loop)
+- [x] Eval benchmark harness (scenarios + long-run + conditions matrix)
+- [x] Encryption at rest (SQLCipher + keychain / file fallback)
+- [x] OTEL telemetry export (`rememora telemetry`)
+- [x] Recursion-gate observability (`rememora usage --hooks`)
 - [x] TUI dashboard for browsing memories
+- [x] Desktop viewer (Tauri, macOS)
+- [ ] Cross-agent transfer beyond Claude→Codex (Gemini runner is the prerequisite)
+- [ ] Vector search via candle + sqlite-vec at production scale (currently feature-gated)
+- [ ] Monitors-based curator (replace Stop-hook with Claude Code `monitors` for simpler architecture)
 
 ## Insights
 

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -77,6 +77,7 @@
           <li><a href="#cmd-evolve">evolve</a></li>
           <li><a href="#cmd-consolidate">consolidate</a></li>
           <li><a href="#cmd-setup">setup</a></li>
+          <li><a href="#cmd-update">update</a></li>
           <li><a href="#cmd-agent-run">agent-run</a></li>
           <li><a href="#cmd-agent-loop">agent-loop</a></li>
           <li><a href="#cmd-encrypt">encrypt / decrypt</a></li>
@@ -138,6 +139,35 @@
 
       <h3>GitHub Releases</h3>
       <p>Pre-built binaries are available on the <a href="https://github.com/Rememora/rememora/releases">Releases page</a>.</p>
+
+      <h3>Staying up to date</h3>
+      <p><code>rememora update</code> hits the GitHub Releases API, compares the latest tag against your running binary, and prints an upgrade hint matched to the install method (Homebrew &middot; <code>cargo install</code> &middot; manual). It never auto-executes the upgrade &mdash; mixed install methods, sudo prompts, and the risk of pushing users onto a release we just shipped make &ldquo;tell, don&rsquo;t do&rdquo; the safer default.</p>
+      <div class="code-window">
+        <div class="code-header">
+          <div class="code-dots"><span class="red"></span><span class="yellow"></span><span class="green"></span></div>
+          <span class="code-title">terminal</span>
+          <button class="code-copy">Copy</button>
+        </div>
+        <div class="code-body">
+<pre><span class="prompt">$</span> <span class="cmd">rememora update</span>                <span class="comment"># hits API, prints status + hint</span>
+<span class="prompt">$</span> <span class="cmd">rememora update</span> <span class="flag">--check</span>        <span class="comment"># respect 24h cache (use from scripts/hooks)</span>
+<span class="prompt">$</span> <span class="cmd">rememora</span> <span class="flag">--json</span> <span class="cmd">update</span>         <span class="comment"># machine-readable output</span>
+<span class="prompt">$</span> <span class="cmd">brew upgrade</span> rememora           <span class="comment"># actual upgrade (Homebrew)</span></pre>
+        </div>
+      </div>
+      <p>The cache lives at <code>~/.rememora/.update-check</code>. Failures (offline, parse error, rate-limited) are silent. Set <code>REMEMORA_NO_UPDATE_CHECK=1</code> to disable entirely.</p>
+      <p>For the Claude Code plugin (separate lineage):</p>
+      <div class="code-window">
+        <div class="code-header">
+          <div class="code-dots"><span class="red"></span><span class="yellow"></span><span class="green"></span></div>
+          <span class="code-title">terminal</span>
+          <button class="code-copy">Copy</button>
+        </div>
+        <div class="code-body">
+<pre><span class="prompt">$</span> <span class="cmd">claude plugin marketplace update</span> rememora
+<span class="prompt">$</span> <span class="cmd">claude plugin update</span> rememora@rememora    <span class="comment"># note the @marketplace suffix</span></pre>
+        </div>
+      </div>
 
       <h3>Feature Flags</h3>
       <table>
@@ -231,14 +261,39 @@
       <table>
         <thead><tr><th>Component</th><th>Type</th><th>What it does</th></tr></thead>
         <tbody>
-          <tr><td><code>SessionStart</code></td><td>Hook</td><td>Loads project context + starts rememora session</td></tr>
-          <tr><td><code>SessionEnd</code></td><td>Hook</td><td>Closes the active session</td></tr>
-          <tr><td><code>Stop</code></td><td>Hook</td><td>Curates memories from the session transcript after each turn</td></tr>
+          <tr><td><code>SessionStart</code></td><td>Hook</td><td>Loads project context (L0 + L1) and opens a tracked session</td></tr>
+          <tr><td><code>UserPromptSubmit</code></td><td>Hook</td><td>Injects top-3 FTS5 hits matching your prompt into the agent&rsquo;s context</td></tr>
+          <tr><td><code>Stop</code></td><td>Hook</td><td>Curates memories from the session transcript after each turn (gated)</td></tr>
+          <tr><td><code>SessionEnd</code></td><td>Hook</td><td>Final-pass curation + closes the active session row</td></tr>
           <tr><td><code>rememora-save</code></td><td>Skill</td><td>Claude autonomously saves decisions, bug fixes, patterns</td></tr>
           <tr><td><code>rememora-search</code></td><td>Skill</td><td>Claude autonomously searches before implementations</td></tr>
           <tr><td><code>/rememora</code></td><td>Command</td><td>Manual save, search, or status check</td></tr>
         </tbody>
       </table>
+
+      <h4>Plugin configuration</h4>
+      <table>
+        <thead><tr><th>Variable</th><th>Default</th><th>Effect</th></tr></thead>
+        <tbody>
+          <tr><td><code>REMEMORA_CURATE_COOLDOWN_SECS</code></td><td><code>300</code></td><td>Minimum idle seconds between automatic curation runs from the <code>Stop</code> hook, per session. Concurrency gate (<code>pgrep</code> on session_id) is independent and always active. Set to <code>0</code> to disable just the cooldown.</td></tr>
+          <tr><td><code>REMEMORA_DISABLE_HOOKS</code></td><td>unset</td><td>Kill-switch for all four hooks. Useful for debugging or temporary opt-out.</td></tr>
+          <tr><td><code>REMEMORA_CURATE_CHILD</code></td><td>unset</td><td>Set internally by the curator on its <code>claude -p</code> subprocesses so the entire hook chain is a no-op inside curator children. Not intended for user override.</td></tr>
+          <tr><td><code>REMEMORA_NO_UPDATE_CHECK</code></td><td>unset</td><td>Disables the GitHub-Releases update check entirely (see <code>rememora update</code>).</td></tr>
+        </tbody>
+      </table>
+
+      <h4>Updating the plugin</h4>
+      <div class="code-window">
+        <div class="code-header">
+          <div class="code-dots"><span class="red"></span><span class="yellow"></span><span class="green"></span></div>
+          <span class="code-title">terminal</span>
+          <button class="code-copy">Copy</button>
+        </div>
+        <div class="code-body">
+<pre><span class="prompt">$</span> <span class="cmd">claude plugin marketplace update</span> rememora
+<span class="prompt">$</span> <span class="cmd">claude plugin update</span> rememora@rememora    <span class="comment"># note the @marketplace suffix</span></pre>
+        </div>
+      </div>
 
       <h3>Claude Code: Alternative (CLAUDE.md)</h3>
       <p>If you prefer manual control instead of the plugin, add to <code>~/.claude/CLAUDE.md</code>:</p>
@@ -691,6 +746,23 @@ Before ending: `rememora session end &lt;id&gt; --summary "..." ...`
 <span class="cmd">rememora</span> <span class="cmd">setup</span> <span class="flag">--apply</span>   <span class="comment"># apply configuration</span></pre>
         </div>
       </div>
+      <p><code>setup --apply</code> opportunistically prints an upgrade hint when a newer release is cached &mdash; silent when up-to-date, offline, or rate-limited.</p>
+
+      <h2 id="cmd-update">update</h2>
+      <p>Check GitHub Releases for a newer rememora and print an upgrade hint matched to your install method (Homebrew &middot; <code>cargo install</code> &middot; manual). Never auto-executes the upgrade.</p>
+      <div class="code-window">
+        <div class="code-header">
+          <div class="code-dots"><span class="red"></span><span class="yellow"></span><span class="green"></span></div>
+          <span class="code-title">usage</span>
+          <button class="code-copy">Copy</button>
+        </div>
+        <div class="code-body">
+<pre><span class="cmd">rememora</span> <span class="cmd">update</span>            <span class="comment"># hits API, prints status + hint</span>
+<span class="cmd">rememora</span> <span class="cmd">update</span> <span class="flag">--check</span>    <span class="comment"># respect 24h cache (use from scripts/hooks)</span>
+<span class="cmd">rememora</span> <span class="flag">--json</span> <span class="cmd">update</span>     <span class="comment"># machine-readable output</span></pre>
+        </div>
+      </div>
+      <p>Cache lives at <code>~/.rememora/.update-check</code>. <code>REMEMORA_NO_UPDATE_CHECK=1</code> disables entirely.</p>
 
       <h2 id="cmd-agent-run">agent-run</h2>
       <p>Dispatch a GitHub issue to Claude CLI with quality gates.</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -57,7 +57,7 @@
     <div class="hero-content">
       <div class="hero-badge">
         <span class="dot"></span>
-        v0.3.0 &mdash; Hierarchical search, plugin install, desktop app
+        v1.5.0 &mdash; Autonomous memory pipeline, marketplace install, update notifications
       </div>
 
       <h1>
@@ -672,40 +672,50 @@
       <div class="reveal" style="max-width: 700px; margin: 0 auto; text-align: left;">
         <div class="glass-card" style="margin-bottom: 16px;">
           <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px;">
-            <h3 style="margin: 0;">v0.3.0</h3>
-            <span style="color: var(--text-muted); font-size: 0.8rem;">April 2026</span>
+            <h3 style="margin: 0;">v1.5.0</h3>
+            <span style="color: var(--text-muted); font-size: 0.8rem;">April 26, 2026</span>
           </div>
           <ul style="margin: 0; padding-left: 20px; line-height: 1.8;">
-            <li><strong>Hierarchical score propagation</strong> &mdash; search boosts related memories via URI tree</li>
-            <li><strong>Claude Code plugin install</strong> &mdash; <code>/plugin install rememora@rememora</code></li>
-            <li><strong>Desktop app</strong> &mdash; Tauri v2 with dashboard, browser, and search</li>
-            <li><strong>Landing page &amp; docs site</strong> &mdash; GitHub Pages with full documentation</li>
+            <li><strong><code>rememora update [--check]</code></strong> &mdash; passive GitHub Releases check; prints upgrade hint matched to your install method (brew / cargo / unknown)</li>
+            <li><strong>Inline upgrade hint in <code>setup --apply</code></strong> &mdash; opportunistic, silent on failure</li>
+            <li><strong>24h cache + opt-out env</strong> &mdash; <code>REMEMORA_NO_UPDATE_CHECK=1</code> for sandboxes</li>
           </ul>
         </div>
 
         <div class="glass-card" style="margin-bottom: 16px;">
           <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px;">
-            <h3 style="margin: 0;">v0.2.0</h3>
-            <span style="color: var(--text-muted); font-size: 0.8rem;">April 2026</span>
+            <h3 style="margin: 0;">v1.4.1</h3>
+            <span style="color: var(--text-muted); font-size: 0.8rem;">April 26, 2026</span>
           </div>
           <ul style="margin: 0; padding-left: 20px; line-height: 1.8;">
-            <li><strong>SQLCipher encryption at rest</strong> &mdash; keychain integration</li>
-            <li><strong>TUI dashboard</strong> &mdash; interactive terminal browser (ratatui)</li>
-            <li><strong>BDD-style tests</strong> &mdash; Given-When-Then test structure</li>
-            <li><strong>Autonomous curation</strong> &mdash; LLM-powered memory extraction from session transcripts</li>
+            <li><strong>Skill frontmatter fix</strong> &mdash; <code>/rememora</code> slash command was silently broken in 1.4.0 (YAML flow-sequence issue with <code>argument-hint: [save|search|status]</code>); now parses cleanly</li>
+            <li><strong>Plugin manifest cleanup</strong> &mdash; dropped unrecognized <code>requirements</code> key</li>
+          </ul>
+        </div>
+
+        <div class="glass-card" style="margin-bottom: 16px;">
+          <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px;">
+            <h3 style="margin: 0;">v1.4.0</h3>
+            <span style="color: var(--text-muted); font-size: 0.8rem;">April 26, 2026</span>
+          </div>
+          <ul style="margin: 0; padding-left: 20px; line-height: 1.8;">
+            <li><strong>Autonomous memory pipeline now actually works</strong> &mdash; 1.2.x had Stop-hook curator silently inert because the parser required an array but modern <code>claude -p --output-format json</code> returns a single object. Stop hook fired, processes spawned, no memories ever landed. Closes the loop end-to-end.</li>
+            <li><strong>14 bugs fixed across setup, hook lifecycle, and concurrency</strong> &mdash; verified across 12 Docker sandbox iterations</li>
+            <li><strong>Curator child session 28x explosion</strong> fixed (<code>REMEMORA_CURATE_CHILD</code> gate now applies to all 4 hooks)</li>
+            <li><strong>SessionEnd tail-pass dedup</strong> &mdash; Stop and SessionEnd no longer race on the same transcript (~50% cost reduction)</li>
           </ul>
         </div>
 
         <div class="glass-card">
           <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px;">
-            <h3 style="margin: 0;">v0.1.0</h3>
-            <span style="color: var(--text-muted); font-size: 0.8rem;">March 2026</span>
+            <h3 style="margin: 0;">Earlier releases</h3>
+            <span style="color: var(--text-muted); font-size: 0.8rem;">March &ndash; April 2026</span>
           </div>
           <ul style="margin: 0; padding-left: 20px; line-height: 1.8;">
-            <li><strong>Core CLI</strong> &mdash; save, search, context, sessions, projects</li>
-            <li><strong>BM25 search</strong> &mdash; FTS5 full-text search, zero dependencies</li>
-            <li><strong>Vector search</strong> &mdash; optional cosine similarity via sqlite-vec + Candle</li>
-            <li><strong>Agent orchestration</strong> &mdash; agent-run, agent-loop, GitHub project board integration</li>
+            <li><strong>v1.2.x</strong> &mdash; SQLCipher encryption at rest, keychain integration, plugin install via marketplace</li>
+            <li><strong>v0.3.x</strong> &mdash; hierarchical score propagation, desktop app (Tauri v2), landing page</li>
+            <li><strong>v0.2.x</strong> &mdash; TUI dashboard, autonomous curation v1, BDD-style tests</li>
+            <li><strong>v0.1.x</strong> &mdash; core CLI (save/search/context/sessions/projects), BM25 + optional vector search, agent orchestration</li>
           </ul>
         </div>
 


### PR DESCRIPTION
## Summary

Brings the public-facing surfaces in line with the v1.4.0 / v1.4.1 / v1.5.0 release arc:

- Landing page (`rememora.ai`) hero badge still said v0.3.0
- README's plugin table didn't list the UserPromptSubmit hook (shipped in 1.4.0 / #87)
- Neither surface mentioned the new `rememora update` subcommand
- Plugin install path (now battle-tested across 12 sandbox iterations) deserved an updated section

## Changes

### `README.md`
- "What's new in v1.5.0" callout below the badges with links to all three release notes pages
- `rememora update [--check]` and `rememora usage [--hooks]` rows in the commands table
- New "Staying up to date" subsection under Install
- Plugin install table now lists all 4 hooks (was missing `UserPromptSubmit`)
- Plugin env-var documentation: `REMEMORA_DISABLE_HOOKS`, `REMEMORA_CURATE_CHILD`
- "Updating the plugin" subsection with marketplace update flow
- Replace stale "124 tests" claim with current count
- Roadmap refresh — drop done items, add cross-agent transfer beyond Claude→Codex, monitors-based curator spike, vector-search-at-scale

### `docs/index.html` (rememora.ai landing)
- Hero badge: `v0.3.0 — Hierarchical search, plugin install, desktop app` → `v1.5.0 — Autonomous memory pipeline, marketplace install, update notifications`
- Releases section: replace 3x v0.x cards with detailed v1.5.0 / v1.4.1 / v1.4.0 cards; consolidate older releases into one summary card

### `docs/docs.html`
- "Staying up to date" subsection in Installation with full update flow
- New `update` command page (added to Commands sidebar)
- Plugin install table: added `UserPromptSubmit` row, gated/final-pass language for Stop and SessionEnd
- "Plugin configuration" subsection with all four env vars (`REMEMORA_CURATE_COOLDOWN_SECS`, `REMEMORA_DISABLE_HOOKS`, `REMEMORA_CURATE_CHILD`, `REMEMORA_NO_UPDATE_CHECK`)
- "Updating the plugin" subsection with marketplace update flow

## Test plan

- [x] HTML balance check: `<div>` count matches `</div>` count for both index.html (177) and docs.html (164)
- [x] `python3 scripts/version.py --check` — all 5 surfaces still synced at 1.5.0 (no version change)
- [x] `cargo test --lib` — 86 passing (no code changes)
- [ ] After merge: GitHub Pages will redeploy automatically (workflow `pages-build-deployment` triggers on push to `main:/docs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)